### PR TITLE
Remove hard dependency on Predis + allow other Redis lib

### DIFF
--- a/.unused.dist.php
+++ b/.unused.dist.php
@@ -28,6 +28,7 @@ return [
         'enlightn/security-checker', // QA tool
         'php-parallel-lint/php-parallel-lint', // QA tool
         'sebastian/phpcpd', // QA tool
+        'ukko/phpredis-phpdoc' // Stubs
     ],
     'excludeDirectories' => [],
     'scanFiles' => [],

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: analyze fix-code test coverage mutation-test validation
+.PHONY: analyze fix-code test coverage validation integration-test
 
 analyze: | vendor
 	$(COMPOSER) exec -v parallel-lint -- src
@@ -22,7 +22,10 @@ coverage: | vendor
 	@if [ -z "`php -v | grep -i 'xdebug'`" ]; then echo "You need to install Xdebug in order to do this action"; exit 1; fi
 	$(COMPOSER) exec -v phpunit -- --coverage-text --color
 
-validation: fix-code analyze test coverage
+integration-test: | vendor
+	$(COMPOSER) exec -v phpunit -- --group integration
+
+validation: fix-code analyze test coverage integration-test
 
 vendor: composer.json
 	$(COMPOSER) install --optimize-autoloader --no-suggest --prefer-dist

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This lib can use several connector for Redis:
  - [Predis](https://github.com/predis/predis/wiki) - Pure PHP implementation
  - [Phpredis](https://github.com/phpredis/phpredis) - PHP extension
  - [Phpiredis](https://github.com/nrk/phpiredis) - PHP extension depending on [hiredis](https://github.com/redis/hiredis)
+ - [Amp\Redis](https://github.com/amphp/redis) - Pure PHP Async implementation
+ - [cheprasov/php-redis-client](https://github.com/cheprasov/php-redis-client) - Pure PHP implementation
+ - [Credis](https://github.com/colinmollenhour/credis) - Pure PHP implementation
+ - [Rediska](https://github.com/Shumkov/Rediska) - Pure PHP implementation
+ - [Redisent](https://github.com/jdp/redisent) - Pure PHP implementation
+ - [TinyRedis](https://github.com/ptrofimov/tinyredisclient) - Pure PHP implementation
 
 You can pick the connector depending of your need.
 
@@ -28,10 +34,28 @@ $clientFacade = new \MacFJA\RediSearch\Redis\Client\ClientFacade();
 $client = $clientFacade->getClient(new \Predis\Client(/* ... */));
 
 // With Phpredis extension
-$client = $clientFacade->getClient(new Redis([/* ... */]));
+$client = $clientFacade->getClient(new \Redis([/* ... */]));
 
 // With Phpiredis extension
 $client = $clientFacade->getClient(phpiredis_connect($host));
+
+// With Amp\Redis
+$client = $clientFacade->getClient(new \Amp\Redis\Redis(new RemoteExecutor(Config::fromUri(/* ... */))));
+
+// With Cheprasov
+$client = $clientFacade->getClient(new \RedisClient\Client\Version\RedisClient6x0([/* ... */]));
+
+// With Rediska
+$client = $clientFacade->getClient(new \Rediska(['servers' => [[/* ... */]]]));
+
+// With Redisent
+$client = $clientFacade->getClient(new \redisent\Redis(/* ... */));
+
+// With TinyRedisClient
+$client = $clientFacade->getClient(new \TinyRedisClient(/* ... */));
+
+// With Credis
+$client = $clientFacade->getClient(new \Credis_Client(/* ... */));
 ```
 
 You can add your own implementation, all you need is to implement the interface `\MacFJA\RediSearch\Redis\Client` and add it to the client facace with:

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,20 @@
         "respect/validation": "^2.0"
     },
     "require-dev": {
+        "amphp/redis": "^1.0",
+        "cheprasov/php-redis-client": "^1.10",
+        "colinmollenhour/credis": "^1.12",
         "enlightn/security-checker": "^1.9",
         "ergebnis/composer-normalize": "^2.13",
         "friendsofphp/php-cs-fixer": "^3.0",
+        "geometria-lab/rediska": "^0.5.10",
         "insolita/unused-scanner": "^2.3",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpmd/phpmd": "^2.10",
         "phpstan/phpstan": "^0.12.92",
         "phpunit/phpunit": "^8.5",
         "predis/predis": "^1.1",
+        "redisent/redisent": "dev-master",
         "roave/security-advisories": "dev-latest",
         "rskuipers/php-assumptions": "^0.8.0",
         "sebastian/phpcpd": "^4.1",
@@ -40,7 +45,12 @@
     "suggest": {
         "ext-phpiredis": "To use Phpiredis extension implementation",
         "ext-phpredis": "To use Phpredis extension implementation",
-        "predis/predis": "To use Predis implementation"
+        "amphp/redis": "To use AmpPhp implementation",
+        "cheprasov/php-redis-client": "To use Cheprasov implementation",
+        "colinmollenhour/credis": "To use Credis implementation",
+        "geometria-lab/rediska": "To use Rediska implementation",
+        "predis/predis": "To use Predis implementation",
+        "redisent/redisent": "To use Redisent implementation"
     },
     "config": {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "php": "^7.2",
         "ext-intl": "*",
         "composer/semver": "^3.2",
-        "predis/predis": "^1.1",
         "respect/validation": "^2.0"
     },
     "require-dev": {
@@ -31,10 +30,17 @@
         "phpmd/phpmd": "^2.10",
         "phpstan/phpstan": "^0.12.92",
         "phpunit/phpunit": "^8.5",
+        "predis/predis": "^1.1",
         "roave/security-advisories": "dev-latest",
         "rskuipers/php-assumptions": "^0.8.0",
         "sebastian/phpcpd": "^4.1",
+        "ukko/phpredis-phpdoc": "dev-master",
         "vimeo/psalm": "^4.7"
+    },
+    "suggest": {
+        "ext-phpiredis": "To use Phpiredis extension implementation",
+        "ext-phpredis": "To use Phpredis extension implementation",
+        "predis/predis": "To use Predis implementation"
     },
     "config": {
         "platform": {

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "phpstan/phpstan": "^0.12.92",
         "phpunit/phpunit": "^8.5",
         "predis/predis": "^1.1",
+        "ptrofimov/tinyredisclient": "^1.1",
         "redisent/redisent": "dev-master",
         "roave/security-advisories": "dev-latest",
         "rskuipers/php-assumptions": "^0.8.0",
@@ -44,12 +45,13 @@
     },
     "suggest": {
         "ext-phpiredis": "To use Phpiredis extension implementation",
-        "ext-phpredis": "To use Phpredis extension implementation",
+        "ext-redis": "To use Phpredis extension implementation",
         "amphp/redis": "To use AmpPhp implementation",
         "cheprasov/php-redis-client": "To use Cheprasov implementation",
         "colinmollenhour/credis": "To use Credis implementation",
         "geometria-lab/rediska": "To use Rediska implementation",
         "predis/predis": "To use Predis implementation",
+        "ptrofimov/tinyredisclient": "To use TinyRedisClient implementation",
         "redisent/redisent": "To use Redisent implementation"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ed68d6965de036262b2505f9aa3eadf",
+    "content-hash": "d631916a7eaceb593add53d973c6cb88",
     "packages": [
         {
             "name": "composer/semver",
@@ -86,72 +86,6 @@
                 }
             ],
             "time": "2021-05-24T12:41:47+00:00"
-        },
-        {
-            "name": "predis/predis",
-            "version": "v1.1.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/predis/predis.git",
-                "reference": "cf5c118a077fbab8b9af1482c20952173125c041"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/predis/predis/zipball/cf5c118a077fbab8b9af1482c20952173125c041",
-                "reference": "cf5c118a077fbab8b9af1482c20952173125c041",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8"
-            },
-            "suggest": {
-                "ext-curl": "Allows access to Webdis when paired with phpiredis",
-                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Predis\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniele Alessandri",
-                    "email": "suppakilla@gmail.com",
-                    "homepage": "http://clorophilla.net",
-                    "role": "Creator & Maintainer"
-                },
-                {
-                    "name": "Till Krüss",
-                    "homepage": "https://till.im",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
-            "homepage": "http://github.com/predis/predis",
-            "keywords": [
-                "nosql",
-                "predis",
-                "redis"
-            ],
-            "support": {
-                "issues": "https://github.com/predis/predis/issues",
-                "source": "https://github.com/predis/predis/tree/v1.1.8"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/tillkruss",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-09-29T17:48:39+00:00"
         },
         {
             "name": "respect/stringifier",
@@ -3110,6 +3044,72 @@
                 }
             ],
             "time": "2021-09-25T07:37:20+00:00"
+        },
+        {
+            "name": "predis/predis",
+            "version": "v1.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/predis/predis.git",
+                "reference": "cf5c118a077fbab8b9af1482c20952173125c041"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/predis/predis/zipball/cf5c118a077fbab8b9af1482c20952173125c041",
+                "reference": "cf5c118a077fbab8b9af1482c20952173125c041",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net",
+                    "role": "Creator & Maintainer"
+                },
+                {
+                    "name": "Till Krüss",
+                    "homepage": "https://till.im",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/predis/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/predis/predis/issues",
+                "source": "https://github.com/predis/predis/tree/v1.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/tillkruss",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-09-29T17:48:39+00:00"
         },
         {
             "name": "psr/cache",
@@ -6241,6 +6241,55 @@
             "time": "2021-07-28T10:34:58+00:00"
         },
         {
+            "name": "ukko/phpredis-phpdoc",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ukko/phpredis-phpdoc.git",
+                "reference": "5ce7ea21e7240f4c60ab9a0f5a9208ea6c2a2f30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ukko/phpredis-phpdoc/zipball/5ce7ea21e7240f4c60ab9a0f5a9208ea6c2a2f30",
+                "reference": "5ce7ea21e7240f4c60ab9a0f5a9208ea6c2a2f30",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "phpredis-phpdoc": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Max Kamashev",
+                    "email": "max.kamashev@gmail.com",
+                    "homepage": "http://max.kamashev.name/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "@phpdoc extension phpredis for IDE autocomplete",
+            "homepage": "https://github.com/ukko/phpredis-phpdoc",
+            "keywords": [
+                "helper",
+                "phpredis",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/ukko/phpredis-phpdoc/issues",
+                "source": "https://github.com/ukko/phpredis-phpdoc/tree/master"
+            },
+            "time": "2021-05-08T16:57:08+00:00"
+        },
+        {
             "name": "vimeo/psalm",
             "version": "4.10.0",
             "source": {
@@ -6457,7 +6506,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "roave/security-advisories": 20
+        "roave/security-advisories": 20,
+        "ukko/phpredis-phpdoc": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6fe468a3d47a4506b963d1d03e7c38af",
+    "content-hash": "7bb89cff485836217af5df89eec3ad68",
     "packages": [
         {
             "name": "composer/semver",
@@ -4219,6 +4219,49 @@
                 "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
             "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "ptrofimov/tinyredisclient",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ptrofimov/tinyredisclient.git",
+                "reference": "7b8d487afa41b74e30d1a68400d89c12d9b82b6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ptrofimov/tinyredisclient/zipball/7b8d487afa41b74e30d1a68400d89c12d9b82b6f",
+                "reference": "7b8d487afa41b74e30d1a68400d89c12d9b82b6f",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Petr Trofimov",
+                    "email": "petrofimov@yandex.ru",
+                    "homepage": "https://github.com/ptrofimov"
+                }
+            ],
+            "description": "The most lightweight Redis client written in PHP",
+            "homepage": "https://github.com/ptrofimov/tinyredisclient",
+            "keywords": [
+                "client",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/ptrofimov/tinyredisclient/issues",
+                "source": "https://github.com/ptrofimov/tinyredisclient/tree/master"
+            },
+            "time": "2013-04-09T19:16:58+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d631916a7eaceb593add53d973c6cb88",
+    "content-hash": "6fe468a3d47a4506b963d1d03e7c38af",
     "packages": [
         {
             "name": "composer/semver",
@@ -459,6 +459,690 @@
             "time": "2021-03-30T17:13:30+00:00"
         },
         {
+            "name": "amphp/cache",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "2b6b5dbb70e54cc914df9952ba7c012bc4cbcd28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/2b6b5dbb70e54cc914df9952ba7c012bc4cbcd28",
+                "reference": "2b6b5dbb70e54cc914df9952ba7c012bc4cbcd28",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^1.2",
+                "php": ">=7.1"
+            },
+            "conflict": {
+                "amphp/file": "<0.2 || >=3"
+            },
+            "require-dev": {
+                "amphp/file": "^1 || ^2",
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.1",
+                "phpunit/phpunit": "^6 | ^7 | ^8 | ^9",
+                "vimeo/psalm": "^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A promise-aware caching API for Amp.",
+            "homepage": "https://github.com/amphp/cache",
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-29T17:12:43+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "852292532294d7972c729a96b49756d781f7c59d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/852292532294d7972c729a96b49756d781f7c59d",
+                "reference": "852292532294d7972c729a96b49756d781f7c59d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "amphp/byte-stream": "^1.1",
+                "amphp/cache": "^1.2",
+                "amphp/parser": "^1",
+                "amphp/windows-registry": "^0.3",
+                "daverandom/libdns": "^2.0.1",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Dns\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-21T19:04:57+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "f83e68f03d5b8e8e0365b8792985a7f341c57ae1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/f83e68f03d5b8e8e0365b8792985a7f341c57ae1",
+                "reference": "f83e68f03d5b8e8e0365b8792985a7f341c57ae1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/is-valid"
+            },
+            "time": "2017-06-06T05:29:10+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "3d36327bf9b4c158cf3010f8f65c00854ec3a8b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/3d36327bf9b4c158cf3010f8f65c00854ec3a8b7",
+                "reference": "3d36327bf9b4c158cf3010f8f65c00854ec3a8b7",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "amphp/byte-stream": "^1.4",
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "phpunit/phpunit": "^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Process\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous process manager.",
+            "homepage": "https://github.com/amphp/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-08T15:55:53+00:00"
+        },
+        {
+            "name": "amphp/redis",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/redis.git",
+                "reference": "b8910b1051b128105f0724b5c95c34db30bd1d45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/redis/zipball/b8910b1051b128105f0724b5c95c34db30bd1d45",
+                "reference": "b8910b1051b128105f0724b5c95c34db30bd1d45",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.2.1",
+                "amphp/cache": "^1.2.1",
+                "amphp/socket": "^1",
+                "amphp/sync": "^1.1",
+                "league/uri-parser": "^1.4",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.1.2",
+                "phpunit/phpunit": "^7 | ^8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Redis\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking Redis client for Amp.",
+            "homepage": "https://github.com/amphp/redis",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/redis/issues",
+                "source": "https://github.com/amphp/redis/tree/v1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-12T18:38:52+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/master"
+            },
+            "time": "2020-03-25T21:39:07+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "a8af9f5d0a66c5fe9567da45a51509e592788fe6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/a8af9f5d0a66c5fe9567da45a51509e592788fe6",
+                "reference": "a8af9f5d0a66c5fe9567da45a51509e592788fe6",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "amphp/byte-stream": "^1.6",
+                "amphp/dns": "^1 || ^0.9",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri-parser": "^1.4",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "vimeo/psalm": "^3.9@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Async socket connection / server tools for Amp.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-09T18:18:48+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "613047ac54c025aa800a9cde5b05c3add7327ed4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/613047ac54c025aa800a9cde5b05c3add7327ed4",
+                "reference": "613047ac54c025aa800a9cde5b05c3add7327ed4",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.1",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/ConcurrentIterator/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Mutex, Semaphore, and other synchronization tools for Amp.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v1.4.0"
+            },
+            "time": "2020-05-07T18:57:50+00:00"
+        },
+        {
+            "name": "amphp/windows-registry",
+            "version": "v0.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/windows-registry.git",
+                "reference": "0f56438b9197e224325e88f305346f0221df1f71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/windows-registry/zipball/0f56438b9197e224325e88f305346f0221df1f71",
+                "reference": "0f56438b9197e224325e88f305346f0221df1f71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "amphp/byte-stream": "^1.4",
+                "amphp/process": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\WindowsRegistry\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Windows Registry Reader.",
+            "support": {
+                "issues": "https://github.com/amphp/windows-registry/issues",
+                "source": "https://github.com/amphp/windows-registry/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-10T16:13:29+00:00"
+        },
+        {
+            "name": "cheprasov/php-redis-client",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cheprasov/php-redis-client.git",
+                "reference": "c3594e0bbc8ee1bc2c11c889ce5dfa0d3b8a6f9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cheprasov/php-redis-client/zipball/c3594e0bbc8ee1bc2c11c889ce5dfa0d3b8a6f9a",
+                "reference": "c3594e0bbc8ee1bc2c11c889ce5dfa0d3b8a6f9a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "cheprasov/php-extra-mocks": "^1.0.0",
+                "phpunit/phpunit": "4.8.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "RedisClient\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexander Cheprasov",
+                    "email": "acheprasov84@gmail.com"
+                }
+            ],
+            "description": "Php client for Redis. It is a fast, fully-functional and user-friendly client for Redis, optimized for performance. RedisClient supports the latest versions of Redis starting from 2.6 to 6.0",
+            "homepage": "http://github.com/cheprasov/php-redis-client",
+            "support": {
+                "issues": "https://github.com/cheprasov/php-redis-client/issues",
+                "source": "https://github.com/cheprasov/php-redis-client/tree/v1.10.0"
+            },
+            "time": "2020-06-20T13:05:24+00:00"
+        },
+        {
+            "name": "colinmollenhour/credis",
+            "version": "v1.12.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/colinmollenhour/credis.git",
+                "reference": "c27faa11724229986335c23f4b6d0f1d8d6547fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/c27faa11724229986335c23f4b6d0f1d8d6547fb",
+                "reference": "c27faa11724229986335c23f4b6d0f1d8d6547fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Client.php",
+                    "Cluster.php",
+                    "Sentinel.php",
+                    "Module.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin Mollenhour",
+                    "email": "colin@mollenhour.com"
+                }
+            ],
+            "description": "Credis is a lightweight interface to the Redis key-value store which wraps the phpredis library when available for better performance.",
+            "homepage": "https://github.com/colinmollenhour/credis",
+            "support": {
+                "issues": "https://github.com/colinmollenhour/credis/issues",
+                "source": "https://github.com/colinmollenhour/credis/tree/v1.12.1"
+            },
+            "time": "2020-11-06T16:09:14+00:00"
+        },
+        {
             "name": "composer/package-versions-deprecated",
             "version": "1.11.99.4",
             "source": {
@@ -594,6 +1278,50 @@
                 }
             ],
             "time": "2021-07-31T17:03:58+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "e8b6d6593d18ac3a6a14666d8a68a4703b2e05f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/e8b6d6593d18ac3a6a14666d8a68a4703b2e05f9",
+                "reference": "e8b6d6593d18ac3a6a14666d8a68a4703b2e05f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.0"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.0.2"
+            },
+            "time": "2019-12-03T09:12:46+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1330,6 +2058,65 @@
             "time": "2021-08-29T20:16:20+00:00"
         },
         {
+            "name": "geometria-lab/rediska",
+            "version": "v0.5.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Shumkov/Rediska.git",
+                "reference": "5b33ba2f1526f9ad30864b42617e34ac370aeae0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Shumkov/Rediska/zipball/5b33ba2f1526f9ad30864b42617e34ac370aeae0",
+                "reference": "5b33ba2f1526f9ad30864b42617e34ac370aeae0",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=3.7.11",
+                "zendframework/zendframework1": ">=1.12.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Rediska": [
+                        "library/",
+                        "tests/library/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "authors": [
+                {
+                    "name": "Maxim Ivanov",
+                    "email": "maximiv@gmail.com"
+                },
+                {
+                    "name": "Ryan Grenz",
+                    "email": "info@ryangrenz.com"
+                },
+                {
+                    "name": "Ivan Shumkov",
+                    "email": "ivan@shumkov.ru"
+                },
+                {
+                    "name": "Till Klampaeckel",
+                    "email": "till@php.net"
+                }
+            ],
+            "description": "Full-featured PHP client for key-value database Redis",
+            "keywords": [
+                "cache",
+                "redis",
+                "sessions",
+                "zend"
+            ],
+            "support": {
+                "issues": "https://github.com/Shumkov/Rediska/issues",
+                "source": "https://github.com/Shumkov/Rediska/tree/v0.5.10"
+            },
+            "time": "2014-08-12T15:02:35+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "6.5.5",
             "source": {
@@ -1659,6 +2446,59 @@
             "time": "2021-07-22T09:24:00+00:00"
         },
         {
+            "name": "kelunik/certificate",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "56542e62d51533d04d0a9713261fea546bff80f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/56542e62d51533d04d0a9713261fea546bff80f6",
+                "reference": "56542e62d51533d04d0a9713261fea546bff80f6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.9",
+                "phpunit/phpunit": "^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.2"
+            },
+            "time": "2019-05-29T19:02:31+00:00"
+        },
+        {
             "name": "league/climate",
             "version": "3.6.0",
             "source": {
@@ -1722,6 +2562,75 @@
                 "source": "https://github.com/thephpleague/climate/tree/3.6.0"
             },
             "time": "2020-10-04T16:02:59+00:00"
+        },
+        {
+            "name": "league/uri-parser",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-parser.git",
+                "reference": "671548427e4c932352d9b9279fdfa345bf63fa00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/671548427e4c932352d9b9279fdfa345bf63fa00",
+                "reference": "671548427e4c932352d9b9279fdfa345bf63fa00",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpstan/phpstan": "^0.9.2",
+                "phpstan/phpstan-phpunit": "^0.9.4",
+                "phpstan/phpstan-strict-rules": "^0.9.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-intl": "Allow parsing RFC3987 compliant hosts",
+                "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "userland URI parser RFC 3986 compliant",
+            "homepage": "https://github.com/thephpleague/uri-parser",
+            "keywords": [
+                "parse_url",
+                "parser",
+                "rfc3986",
+                "rfc3987",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/uri-parser/issues",
+                "source": "https://github.com/thephpleague/uri-parser/tree/master"
+            },
+            "time": "2018-11-22T07:55:51+00:00"
         },
         {
             "name": "localheinz/diff",
@@ -3356,6 +4265,52 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "redisent/redisent",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jdp/redisent.git",
+                "reference": "0a9e40710153a5f36fbafe7d1f7fe0de3f723be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jdp/redisent/zipball/0a9e40710153a5f36fbafe7d1f7fe0de3f723be4",
+                "reference": "0a9e40710153a5f36fbafe7d1f7fe0de3f723be4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-sockets": "*",
+                "php": ">=5.3.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "redisent": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Poliey",
+                    "homepage": "http://justinpoliey.com/"
+                }
+            ],
+            "description": "Redisent",
+            "homepage": "https://github.com/jdp/redisent",
+            "keywords": [
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/jdp/redisent/issues",
+                "source": "https://github.com/jdp/redisent/tree/master"
+            },
+            "time": "2013-11-19T04:55:46+00:00"
+        },
+        {
             "name": "roave/security-advisories",
             "version": "dev-latest",
             "source": {
@@ -4536,6 +5491,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -6506,6 +7462,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "redisent/redisent": 20,
         "roave/security-advisories": 20,
         "ukko/phpredis-phpdoc": 20
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,9 @@ parameters:
     paths:
         - src
         - tests
+    excludePaths:
+        analyse:
+            - tests/psalm/stubs/phpiredis.php
     ignoreErrors:
         - '#Method MacFJA\\RediSearch\\Redis\\Command\\\w+::getLanguageOptions\(\) should return#'
         - '#uses generic trait MacFJA\\RediSearch\\Redis\\Command\\Option\\DecoratedOptionTrait but does not specify its types: T#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,8 +11,18 @@
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>
+            <exclude>tests/integration</exclude>
+        </testsuite>
+        <testsuite name="integration">
+            <directory suffix="Test.php">tests/integration</directory>
         </testsuite>
     </testsuites>
+
+    <groups>
+        <exclude>
+            <group>integration</group>
+        </exclude>
+    </groups>
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="true">

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,4 +12,8 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <stubs>
+        <file name="vendor/ukko/phpredis-phpdoc/src/Redis.php"/>
+        <file name="tests/psalm/stubs/phpiredis.php"/>
+    </stubs>
 </psalm>

--- a/src/Exception/UnexpectedServerResponseException.php
+++ b/src/Exception/UnexpectedServerResponseException.php
@@ -19,50 +19,36 @@ declare(strict_types=1);
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace MacFJA\RediSearch\Redis\Command;
+namespace MacFJA\RediSearch\Exception;
 
-use function is_array;
-use MacFJA\RediSearch\Exception\UnexpectedServerResponseException;
-use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use MacFJA\RediSearch\Redis\Response\InfoResponse;
+use function is_string;
+use UnexpectedValueException;
 
-class Info extends AbstractCommand
+class UnexpectedServerResponseException extends UnexpectedValueException
 {
-    public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
-    {
-        parent::__construct([
-            'index' => new NamelessOption(null, '>=2.0.0'),
-        ], $rediSearchVersion);
-    }
+    /** @var mixed */
+    private $response;
 
-    public function setIndex(string $name): self
+    /**
+     * @param mixed $response
+     */
+    public function __construct($response, ?string $message = null)
     {
-        $this->options['index']->setValue($name);
-
-        return $this;
-    }
-
-    public function getId(): string
-    {
-        return 'FT.INFO';
+        $this->response = $response;
+        $additional = '';
+        if (is_string($message)) {
+            $additional = ': '.$message;
+        }
+        parent::__construct('Unexpected response from the Redis server'.$additional);
     }
 
     /**
-     * @param array|mixed $data
+     * @codeCoverageIgnore
      *
-     * @return InfoResponse
+     * @return mixed
      */
-    public function parseResponse($data)
+    public function getResponse()
     {
-        if (!is_array($data)) {
-            throw new UnexpectedServerResponseException($data);
-        }
-
-        return new InfoResponse($data);
-    }
-
-    protected function getRequiredOptions(): array
-    {
-        return ['index'];
+        return $this->response;
     }
 }

--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -29,12 +29,11 @@ use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
+use MacFJA\RediSearch\Redis\Client;
 use MacFJA\RediSearch\Redis\Command\AbstractCommand;
 use MacFJA\RediSearch\Redis\Command\AddFieldOptionTrait;
 use MacFJA\RediSearch\Redis\Command\Create;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\CreateCommandFieldOption;
-use Predis\ClientInterface;
-use Predis\Response\ResponseInterface;
 use RuntimeException;
 use function strlen;
 
@@ -168,11 +167,14 @@ class IndexBuilder
         return $this;
     }
 
-    public function create(ClientInterface $client, string $rediSearchVersion = AbstractCommand::MIN_IMPLEMENTED_VERSION): ResponseInterface
+    /**
+     * @return mixed|string
+     */
+    public function create(Client $client, string $rediSearchVersion = AbstractCommand::MIN_IMPLEMENTED_VERSION)
     {
         $command = $this->getCommand($rediSearchVersion);
 
-        return $client->executeCommand($command);
+        return $client->execute($command);
     }
 
     /**

--- a/src/Redis/Client.php
+++ b/src/Redis/Client.php
@@ -19,42 +19,38 @@ declare(strict_types=1);
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace MacFJA\RediSearch\Redis\Command;
+namespace MacFJA\RediSearch\Redis;
 
-use MacFJA\RediSearch\Redis\Command;
-
-class IndexList implements Command
+interface Client
 {
-    /** @var string */
-    private $rediSearchVersion = AbstractCommand::MIN_IMPLEMENTED_VERSION;
-
-    public function getId(): string
-    {
-        return 'FT._LIST';
-    }
-
-    public function getRediSearchVersion(): string
-    {
-        return $this->rediSearchVersion;
-    }
+    /**
+     * @param mixed $redis
+     */
+    public static function make($redis): Client;
 
     /**
-     * @return IndexList
+     * @ return array<mixed>|int|Response|string
+     *
+     * @return mixed
      */
-    public function setRediSearchVersion(string $rediSearchVersion): Command
-    {
-        $this->rediSearchVersion = $rediSearchVersion;
+    public function execute(Command $command);
 
-        return $this;
-    }
+    /**
+     * @param float|int|string $args
+     *
+     * @return mixed
+     */
+    public function executeRaw(...$args);
 
-    public function getArguments(): array
-    {
-        return [];
-    }
+    /**
+     * @param Command ...$commands
+     *
+     * @return array<mixed>
+     */
+    public function pipeline(Command ...$commands): array;
 
-    public function parseResponse($data)
-    {
-        return $data;
-    }
+    /**
+     * @param mixed $redis
+     */
+    public static function supports($redis): bool;
 }

--- a/src/Redis/Client/AbstractClient.php
+++ b/src/Redis/Client/AbstractClient.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Client;
+
+use function count;
+use MacFJA\RediSearch\Redis\Client;
+use MacFJA\RediSearch\Redis\Command;
+
+abstract class AbstractClient implements Client
+{
+    public function pipeline(Command ...$commands): array
+    {
+        $results = $this->doPipeline(...$commands);
+
+        return array_map(static function ($result, $index) use ($commands) {
+            return $commands[$index]->parseResponse($result);
+        }, $results, array_keys($results));
+    }
+
+    /**
+     * @param Command ...$commands
+     *
+     * @return array<mixed>
+     */
+    abstract protected function doPipeline(Command ...$commands): array;
+
+    protected static function fcqnExists(string $fcqn): bool
+    {
+        return class_exists($fcqn) || interface_exists($fcqn);
+    }
+
+    /**
+     * @param array<string,array<string>> $classesMethods
+     * @param array<string>               $functions
+     */
+    protected function getMissingMessage(string $name, bool $isExtension, array $classesMethods, array $functions = []): string
+    {
+        $classes = array_keys($classesMethods);
+        $methods = array_map(static function (string $class, array $methods) {
+            return array_map(static function ($method) use ($class) {
+                return $class.'::'.$method;
+            }, $methods);
+        }, $classes, $classesMethods);
+        $methods = array_reduce($methods, static function ($flat, $methods) {
+            return array_merge($flat, $methods);
+        }, []);
+
+        $message = 'The dependency '.$name.' is missing.'.PHP_EOL.'Install the dependency';
+        if (true === $isExtension) {
+            $message = 'The extension '.$name.' is missing.'.PHP_EOL.'Install the extension';
+        }
+        $message .= ' or use a polyfill that provide';
+
+        $classesMessage = null;
+        if (1 === count($classes)) {
+            $classesMessage = ' the class "'.reset($classes).'"';
+        } elseif (count($classes) > 1) {
+            $classesMessage = ' the classes "'.implode('", "', $classes).'"';
+        }
+        $methodsMessage = null;
+        if (1 === count($methods)) {
+            $methodsMessage = ' the method "'.reset($methods).'"';
+        } elseif (count($methods) > 1) {
+            $methodsMessage = ' the methods "'.implode('", "', $methods).'"';
+        }
+        $functionsMessage = null;
+        if (1 === count($functions)) {
+            $functionsMessage = ' the function "'.reset($functions).'"';
+        } elseif (count($functions) > 1) {
+            $functionsMessage = ' the functions "'.implode('", "', $functions).'"';
+        }
+
+        $message .= implode(' and ', array_filter([$classesMessage, $methodsMessage, $functionsMessage]));
+
+        return $message;
+    }
+}

--- a/src/Redis/Client/AbstractClient.php
+++ b/src/Redis/Client/AbstractClient.php
@@ -27,6 +27,9 @@ use MacFJA\RediSearch\Redis\Command;
 
 abstract class AbstractClient implements Client
 {
+    /** @var bool */
+    public static $disableNotice = false;
+
     public function pipeline(Command ...$commands): array
     {
         $results = $this->doPipeline(...$commands);
@@ -68,28 +71,29 @@ abstract class AbstractClient implements Client
         if (true === $isExtension) {
             $message = 'The extension '.$name.' is missing.'.PHP_EOL.'Install the extension';
         }
-        $message .= ' or use a polyfill that provide';
+        $message .= ' or use a polyfill that provide ';
 
         $classesMessage = null;
         if (1 === count($classes)) {
-            $classesMessage = ' the class "'.reset($classes).'"';
+            $classesMessage = 'the class "'.reset($classes).'"';
         } elseif (count($classes) > 1) {
-            $classesMessage = ' the classes "'.implode('", "', $classes).'"';
+            $classesMessage = 'the classes "'.implode('", "', $classes).'"';
         }
         $methodsMessage = null;
         if (1 === count($methods)) {
-            $methodsMessage = ' the method "'.reset($methods).'"';
+            $methodsMessage = 'the method "'.reset($methods).'"';
         } elseif (count($methods) > 1) {
-            $methodsMessage = ' the methods "'.implode('", "', $methods).'"';
+            $methodsMessage = 'the methods "'.implode('", "', $methods).'"';
         }
         $functionsMessage = null;
         if (1 === count($functions)) {
-            $functionsMessage = ' the function "'.reset($functions).'"';
+            $functionsMessage = 'the function "'.reset($functions).'"';
         } elseif (count($functions) > 1) {
-            $functionsMessage = ' the functions "'.implode('", "', $functions).'"';
+            $functionsMessage = 'the functions "'.implode('", "', $functions).'"';
         }
 
         $message .= implode(' and ', array_filter([$classesMessage, $methodsMessage, $functionsMessage]));
+        $message .= '.';
 
         return $message;
     }

--- a/src/Redis/Client/CheprasovRedisClient.php
+++ b/src/Redis/Client/CheprasovRedisClient.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Client;
+
+use Closure;
+use MacFJA\RediSearch\Redis\Client;
+use MacFJA\RediSearch\Redis\Command;
+use RedisClient\Client\AbstractRedisClient;
+use RedisClient\Pipeline\PipelineInterface;
+use RuntimeException;
+
+/**
+ * @codeCoverageIgnore
+ */
+class CheprasovRedisClient extends AbstractClient
+{
+    /** @var AbstractRedisClient */
+    private $redis;
+
+    private function __construct(AbstractRedisClient $redis)
+    {
+        if (!static::supports($redis)) {
+            throw new RuntimeException($this->getMissingMessage('Cheprasov Redis', false, [
+                AbstractRedisClient::class => ['executeRaw', 'pipeline'],
+                PipelineInterface::class => [],
+            ]));
+        }
+        $this->redis = $redis;
+    }
+
+    public static function make($redis): Client
+    {
+        return new self($redis);
+    }
+
+    public function execute(Command $command)
+    {
+        $response = $this->redis->executeRaw(array_merge([$command->getId()], $command->getArguments()));
+
+        return $command->parseResponse($response);
+    }
+
+    public function executeRaw(...$args)
+    {
+        return $this->redis->executeRaw(array_map('strval', $args));
+    }
+
+    public static function supports($redis): bool
+    {
+        return $redis instanceof AbstractRedisClient
+            && static::fcqnExists(PipelineInterface::class)
+            && method_exists(AbstractRedisClient::class, 'executeRaw')
+            && method_exists(AbstractRedisClient::class, 'pipeline');
+    }
+
+    protected function doPipeline(Command ...$commands): array
+    {
+        trigger_error('Warning, a workaround is used to enable custom command in pipeline for \\RedisClient\\Pipeline\\PipelineInterface', E_USER_NOTICE);
+
+        return $this->redis->pipeline(function (PipelineInterface $pipeline) use ($commands): void {
+            foreach ($commands as $command) {
+                $closure = Closure::fromCallable(function () use ($command): void {
+                    // @phpstan-ignore-next-line
+                    $this->returnCommand(array_merge([$command->getId()], $command->getArguments()), null);
+                });
+                $closure->call($pipeline);
+            }
+        });
+    }
+}

--- a/src/Redis/Client/CheprasovRedisClient.php
+++ b/src/Redis/Client/CheprasovRedisClient.php
@@ -74,7 +74,8 @@ class CheprasovRedisClient extends AbstractClient
 
     protected function doPipeline(Command ...$commands): array
     {
-        trigger_error('Warning, a workaround is used to enable custom command in pipeline for \\RedisClient\\Pipeline\\PipelineInterface', E_USER_NOTICE);
+        false === static::$disableNotice
+            && trigger_error('Warning, a workaround is used to enable custom command in pipeline for \\RedisClient\\Pipeline\\PipelineInterface', E_USER_NOTICE);
 
         return $this->redis->pipeline(function (PipelineInterface $pipeline) use ($commands): void {
             foreach ($commands as $command) {

--- a/src/Redis/Client/ClientFacade.php
+++ b/src/Redis/Client/ClientFacade.php
@@ -21,9 +21,14 @@ declare(strict_types=1);
 
 namespace MacFJA\RediSearch\Redis\Client;
 
+use Amp\Redis\Redis as AmpRedis;
+use Credis_Client as CredisRedis;
 use MacFJA\RediSearch\Redis\Client;
-use Predis\ClientInterface;
-use Redis;
+use Predis\ClientInterface as PredisRedis;
+use Redis as PhpredisRedis;
+use RedisClient\Client\AbstractRedisClient as CheprasovRedis;
+use redisent\Redis as RedisentRedis;
+use Rediska as RediskaRedis;
 use RuntimeException;
 
 /**
@@ -32,10 +37,19 @@ use RuntimeException;
 class ClientFacade
 {
     /** @var array<string> */
-    private $factories = [PhpiredisClient::class, PhpredisClient::class, PredisClient::class];
+    private $factories = [
+        PredisClient::class,
+        CredisClient::class,
+        PhpredisClient::class,
+        PhpiredisClient::class,
+        CheprasovRedisClient::class,
+        RedisentClient::class,
+        RediskaClient::class,
+        AmpRedisClient::class,
+    ];
 
     /**
-     * @param ClientInterface|mixed|Redis|resource $redis
+     * @param AmpRedis|CheprasovRedis|CredisRedis|mixed|PhpredisRedis|PredisRedis|RedisentRedis|RediskaRedis|resource $redis
      */
     public function getClient($redis): Client
     {

--- a/src/Redis/Client/PhpiredisClient.php
+++ b/src/Redis/Client/PhpiredisClient.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Client;
+
+use Exception;
+use function function_exists;
+use function is_resource;
+use MacFJA\RediSearch\Redis\Client;
+use MacFJA\RediSearch\Redis\Command;
+use RuntimeException;
+
+/**
+ * @codeCoverageIgnore
+ */
+class PhpiredisClient implements Client
+{
+    /** @var resource */
+    private $redis;
+
+    /**
+     * @param resource $redis
+     */
+    private function __construct($redis)
+    {
+        $this->validateEnvironment();
+        $this->redis = $redis;
+    }
+
+    public function execute(Command $command)
+    {
+        $this->validateEnvironment();
+        $rawResponse = phpiredis_command_bs($this->redis, array_merge([$command->getId()], $command->getArguments()));
+
+        return $command->parseResponse($rawResponse);
+    }
+
+    public static function supports($redis): bool
+    {
+        if (!is_resource($redis)
+            || !function_exists('phpiredis_command_bs')
+            || !function_exists('phpiredis_multi_command_bs')
+        ) {
+            return false;
+        }
+
+        try {
+            $response = (string) phpiredis_command_bs($redis, ['PING']);
+
+            return 'pong' === strtolower($response);
+        } catch (Exception $exception) {
+            return false;
+        }
+    }
+
+    public static function make($redis): Client
+    {
+        return new self($redis);
+    }
+
+    public function executeRaw(...$args)
+    {
+        $this->validateEnvironment();
+
+        $args = array_map('strval', $args);
+
+        return phpiredis_command_bs($this->redis, $args);
+    }
+
+    public function pipeline(Command ...$commands): array
+    {
+        $results = phpiredis_multi_command_bs($this->redis, array_map(static function (Command $command) {
+            return array_merge([$command->getId()], $command->getArguments());
+        }, $commands));
+
+        return array_map(static function ($result, $index) use ($commands) {
+            return $commands[$index]->parseResponse($result);
+        }, $results, array_keys($results));
+    }
+
+    /**
+     * @psalm-assert function_exists('phpiredis_command')
+     */
+    private function validateEnvironment(): void
+    {
+        if (!function_exists('phpiredis_command_bs') || !function_exists('phpiredis_multi_command_bs')) {
+            throw new RuntimeException(
+                'The extension phpiredis is missing.'.PHP_EOL.
+                'Install the extension or use a polyfill that provide the functions "phpiredis_command_bs" and "phpiredis_multi_command_bs"'
+            );
+        }
+    }
+}

--- a/src/Redis/Client/PredisClient.php
+++ b/src/Redis/Client/PredisClient.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Client;
+
+use function assert;
+use MacFJA\RediSearch\Redis\Client;
+use MacFJA\RediSearch\Redis\Command;
+use Predis\ClientContextInterface;
+use Predis\ClientInterface;
+use Predis\Command\RawCommand;
+use RuntimeException;
+
+/**
+ * @codeCoverageIgnore
+ */
+class PredisClient implements Client
+{
+    /** @var ClientInterface */
+    private $redis;
+
+    private function __construct(ClientInterface $redis)
+    {
+        if (
+            !static::fcqnExists(\Predis\Command\Command::class)
+            || !static::fcqnExists(ClientContextInterface::class)
+            || !method_exists(ClientInterface::class, 'executeCommand')
+            || !method_exists($redis, 'pipeline')
+            || !method_exists(ClientContextInterface::class, 'executeCommand')
+        ) {
+            throw new RuntimeException(
+                'Dependency Predis is missing.'.PHP_EOL.
+                'Install the dependency or use a polyfill that provide the classes'.
+                ' "\\Predis\\Command\\Command" and "\\Predis\\ClientInterface" and "\\Predis\\ClientContextInterface"'.
+                ' and functions "\\Predis\\ClientInterface::executeCommand" and "\\Predis\\ClientInterface::pipeline"'.
+                ' and "\\Predis\\ClientContextInterface::executeCommand"'
+            );
+        }
+        $this->redis = $redis;
+    }
+
+    public function execute(Command $command)
+    {
+        $rawResponse = $this->redis->executeCommand(new RawCommand(array_merge([$command->getId()], $command->getArguments())));
+
+        return $command->parseResponse($rawResponse);
+    }
+
+    public static function supports($redis): bool
+    {
+        if (
+            !static::fcqnExists(ClientInterface::class)
+            || !static::fcqnExists(RawCommand::class)
+        ) {
+            return false;
+        }
+
+        return $redis instanceof ClientInterface
+            && method_exists($redis, 'executeCommand')
+            && method_exists($redis, 'pipeline');
+    }
+
+    public static function make($redis): Client
+    {
+        return new self($redis);
+    }
+
+    /**
+     * @inheridoc
+     */
+    public function executeRaw(...$args)
+    {
+        return $this->redis->executeCommand(new RawCommand($args));
+    }
+
+    public function pipeline(Command ...$commands): array
+    {
+        assert(method_exists($this->redis, 'pipeline'));
+        $results = $this->redis->pipeline(static function (ClientContextInterface $pipeline) use ($commands): void {
+            foreach ($commands as $command) {
+                $pipeline->executeCommand(new RawCommand(array_merge([$command->getId()], $command->getArguments())));
+            }
+        });
+
+        return array_map(static function ($result, $index) use ($commands) {
+            return $commands[$index]->parseResponse($result);
+        }, $results, array_keys($results));
+    }
+
+    private static function fcqnExists(string $fcqn): bool
+    {
+        return class_exists($fcqn) || interface_exists($fcqn);
+    }
+}

--- a/src/Redis/Client/RedisentClient.php
+++ b/src/Redis/Client/RedisentClient.php
@@ -21,16 +21,15 @@ declare(strict_types=1);
 
 namespace MacFJA\RediSearch\Redis\Client;
 
-use function count;
 use MacFJA\RediSearch\Redis\Client;
 use MacFJA\RediSearch\Redis\Command;
-use Redis;
+use redisent\Redis;
 use RuntimeException;
 
 /**
  * @codeCoverageIgnore
  */
-class PhpredisClient extends AbstractClient
+class RedisentClient extends AbstractClient
 {
     /** @var Redis */
     private $redis;
@@ -38,30 +37,11 @@ class PhpredisClient extends AbstractClient
     private function __construct(Redis $redis)
     {
         if (!static::supports($redis)) {
-            throw new RuntimeException($this->getMissingMessage('phpredis', true, [
-                Redis::class => ['rawCommand', 'multi', 'exec'],
+            throw new RuntimeException($this->getMissingMessage('Redisent', false, [
+                Redis::class => ['__call', 'pipeline', 'uncork'],
             ]));
         }
         $this->redis = $redis;
-    }
-
-    public function execute(Command $command)
-    {
-        $arguments = $command->getArguments();
-        if (0 === count($arguments)) {
-            $arguments = [null];
-        }
-        $rawResponse = $this->redis->rawCommand($command->getId(), ...$arguments);
-
-        return $command->parseResponse($rawResponse);
-    }
-
-    public static function supports($redis): bool
-    {
-        return $redis instanceof Redis
-            && method_exists($redis, 'rawCommand')
-            && method_exists($redis, 'multi')
-            && method_exists($redis, 'exec');
     }
 
     public static function make($redis): Client
@@ -69,29 +49,35 @@ class PhpredisClient extends AbstractClient
         return new self($redis);
     }
 
+    public function execute(Command $command)
+    {
+        $result = $this->redis->__call($command->getId(), $command->getArguments());
+
+        return $command->parseResponse($result);
+    }
+
     public function executeRaw(...$args)
     {
-        if (count($args) < 1) {
-            return null;
-        }
-        if (count($args) < 2) {
-            $args[] = null;
-        }
-        // @phpstan-ignore-next-line
-        return $this->redis->rawCommand(...$args);
+        $command = array_shift($args);
+
+        return $this->redis->__call($command, $args);
+    }
+
+    public static function supports($redis): bool
+    {
+        return $redis instanceof Redis
+            && method_exists($redis, '__call')
+            && method_exists($redis, 'pipeline')
+            && method_exists($redis, 'uncork');
     }
 
     protected function doPipeline(Command ...$commands): array
     {
-        $pipeline = $this->redis->multi();
+        $pipeline = $this->redis->pipeline();
         foreach ($commands as $command) {
-            $arguments = $command->getArguments();
-            if (0 === count($arguments)) {
-                $arguments = [null];
-            }
-            $pipeline = $pipeline->rawCommand($command->getId(), ...$arguments);
+            $pipeline = $pipeline->__call($command->getId(), $command->getArguments());
         }
 
-        return $pipeline->exec();
+        return $pipeline->uncork();
     }
 }

--- a/src/Redis/Client/RediskaClient.php
+++ b/src/Redis/Client/RediskaClient.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Client;
+
+use function in_array;
+use MacFJA\RediSearch\Redis\Client;
+use MacFJA\RediSearch\Redis\Command;
+use MacFJA\RediSearch\Redis\Initializer;
+use Rediska;
+use Rediska_Command_Abstract;
+use Rediska_Commands;
+use Rediska_Connection_Exec;
+use RuntimeException;
+
+/**
+ * @codeCoverageIgnore
+ */
+class RediskaClient extends AbstractClient
+{
+    /** @var Rediska */
+    private $redis;
+
+    private function __construct(Rediska $redis)
+    {
+        if (!static::supports($redis)) {
+            throw new RuntimeException($this->getMissingMessage('Rediska', false, [
+                Rediska::class => ['__class', 'pipeline'],
+                Rediska_Command_Abstract::class => [],
+                Rediska_Connection_Exec::class => [],
+                Rediska_Commands::class => ['add', 'getList'],
+            ]));
+        }
+        Initializer::registerCommandsRediska();
+        $this->redis = $redis;
+    }
+
+    public static function make($redis): Client
+    {
+        return new self($redis);
+    }
+
+    public function execute(Command $command)
+    {
+        $result = $this->redis->__call('__redisearch', array_merge([$command->getId()], $command->getArguments()));
+
+        return $command->parseResponse($result);
+    }
+
+    public function executeRaw(...$args)
+    {
+        $command = (string) $args[0];
+        $commands = array_keys(Rediska_Commands::getList());
+
+        if (in_array(strtolower($command), $commands, true)) {
+            array_shift($args);
+
+            return $this->redis->__call($command, $args);
+        }
+
+        return $this->redis->__call('__redisearch', $args);
+    }
+
+    public static function supports($redis): bool
+    {
+        return $redis instanceof Rediska
+            && static::fcqnExists(Rediska_Commands::class)
+            && static::fcqnExists(Rediska_Command_Abstract::class)
+            && static::fcqnExists(Rediska_Connection_Exec::class)
+            && method_exists($redis, '__call')
+            && method_exists(Rediska_Commands::class, 'add')
+            && method_exists($redis, 'pipeline');
+    }
+
+    protected function doPipeline(Command ...$commands): array
+    {
+        $pipeline = $this->redis->pipeline();
+        foreach ($commands as $command) {
+            $pipeline = $pipeline->__call('__redisearch', array_merge([$command->getId()], $command->getArguments()));
+        }
+
+        return $pipeline->execute();
+    }
+}

--- a/src/Redis/Command.php
+++ b/src/Redis/Command.php
@@ -19,42 +19,25 @@ declare(strict_types=1);
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace MacFJA\RediSearch\Redis\Command;
+namespace MacFJA\RediSearch\Redis;
 
-use MacFJA\RediSearch\Redis\Command;
-
-class IndexList implements Command
+interface Command
 {
-    /** @var string */
-    private $rediSearchVersion = AbstractCommand::MIN_IMPLEMENTED_VERSION;
+    public function getId(): string;
 
-    public function getId(): string
-    {
-        return 'FT._LIST';
-    }
+    public function getRediSearchVersion(): string;
 
-    public function getRediSearchVersion(): string
-    {
-        return $this->rediSearchVersion;
-    }
+    public function setRediSearchVersion(string $rediSearchVersion): self;
 
     /**
-     * @return IndexList
+     * @return array<mixed>
      */
-    public function setRediSearchVersion(string $rediSearchVersion): Command
-    {
-        $this->rediSearchVersion = $rediSearchVersion;
+    public function getArguments(): array;
 
-        return $this;
-    }
-
-    public function getArguments(): array
-    {
-        return [];
-    }
-
-    public function parseResponse($data)
-    {
-        return $data;
-    }
+    /**
+     * @param array<mixed>|float|int|mixed|string $data
+     *
+     * @return array<mixed>|int|Response|string
+     */
+    public function parseResponse($data);
 }

--- a/src/Redis/Command/AbstractCommand.php
+++ b/src/Redis/Command/AbstractCommand.php
@@ -64,16 +64,6 @@ abstract class AbstractCommand implements Command
     }
 
     /**
-     * @param array<mixed>|float|int|mixed|string $data
-     *
-     * @return mixed|string
-     */
-    public function parseResponse($data)
-    {
-        return $this->transformParsedResponse($data);
-    }
-
-    /**
      * @return array<float|int|string>
      */
     public function getArguments(): array
@@ -99,19 +89,21 @@ abstract class AbstractCommand implements Command
     }
 
     /**
-     * @return array<string>
-     */
-    abstract protected function getRequiredOptions(): array;
-
-    /**
-     * @param mixed $data
+     * @codeCoverageIgnore
+     *
+     * @param array<mixed>|float|int|mixed|string $data
      *
      * @return mixed
      */
-    protected function transformParsedResponse($data)
+    public function parseResponse($data)
     {
         return $data;
     }
+
+    /**
+     * @return array<string>
+     */
+    abstract protected function getRequiredOptions(): array;
 
     /**
      * @return array<string>

--- a/src/Redis/Command/Aggregate.php
+++ b/src/Redis/Command/Aggregate.php
@@ -160,7 +160,7 @@ class Aggregate extends AbstractCommand implements PaginatedCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.AGGREGATE';
     }

--- a/src/Redis/Command/Aggregate.php
+++ b/src/Redis/Command/Aggregate.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis\Command;
 
 use function assert;
-use function is_int;
 use MacFJA\RediSearch\Redis\Command\AggregateCommand\ApplyOption;
 use MacFJA\RediSearch\Redis\Command\AggregateCommand\GroupByOption;
 use MacFJA\RediSearch\Redis\Command\AggregateCommand\LimitOption;
@@ -198,7 +197,8 @@ class Aggregate extends AbstractCommand implements PaginatedCommand
         }
 
         $totalCount = array_shift($data);
-        assert(is_int($totalCount));
+        assert(is_numeric($totalCount));
+        $totalCount = (int) $totalCount;
 
         $items = array_map(static function (array $document) {
             return new AggregateResponseItem(self::getPairs($document));

--- a/src/Redis/Command/AliasAdd.php
+++ b/src/Redis/Command/AliasAdd.php
@@ -22,11 +22,7 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis\Command;
 
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class AliasAdd extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -51,7 +47,7 @@ class AliasAdd extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.ALIASADD';
     }

--- a/src/Redis/Command/AliasDel.php
+++ b/src/Redis/Command/AliasDel.php
@@ -22,11 +22,7 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis\Command;
 
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class AliasDel extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -43,7 +39,7 @@ class AliasDel extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.ALIASDEL';
     }

--- a/src/Redis/Command/AliasUpdate.php
+++ b/src/Redis/Command/AliasUpdate.php
@@ -22,11 +22,7 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis\Command;
 
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class AliasUpdate extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -51,7 +47,7 @@ class AliasUpdate extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.ALIASUPDATE';
     }

--- a/src/Redis/Command/Alter.php
+++ b/src/Redis/Command/Alter.php
@@ -23,11 +23,7 @@ namespace MacFJA\RediSearch\Redis\Command;
 
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class Alter extends AbstractCommand
 {
     use AddFieldOptionTrait;
@@ -49,7 +45,7 @@ class Alter extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.ALTER';
     }

--- a/src/Redis/Command/Config.php
+++ b/src/Redis/Command/Config.php
@@ -53,7 +53,7 @@ class Config extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.CONFIG';
     }

--- a/src/Redis/Command/ConfigSet.php
+++ b/src/Redis/Command/ConfigSet.php
@@ -24,11 +24,7 @@ namespace MacFJA\RediSearch\Redis\Command;
 use MacFJA\RediSearch\Redis\Command\Option\CustomValidatorOption;
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class ConfigSet extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -57,7 +53,7 @@ class ConfigSet extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.CONFIG';
     }

--- a/src/Redis/Command/Create.php
+++ b/src/Redis/Command/Create.php
@@ -27,11 +27,7 @@ use MacFJA\RediSearch\Redis\Command\Option\NamedOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
 use MacFJA\RediSearch\Redis\Command\Option\NotEmptyOption;
 use MacFJA\RediSearch\Redis\Command\Option\NumberedOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class Create extends AbstractCommand
 {
     use LanguageOptionTrait;
@@ -190,7 +186,7 @@ class Create extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.CREATE';
     }

--- a/src/Redis/Command/CursorDel.php
+++ b/src/Redis/Command/CursorDel.php
@@ -23,11 +23,7 @@ namespace MacFJA\RediSearch\Redis\Command;
 
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class CursorDel extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -53,7 +49,7 @@ class CursorDel extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.CURSOR';
     }

--- a/src/Redis/Command/CursorRead.php
+++ b/src/Redis/Command/CursorRead.php
@@ -25,6 +25,7 @@ use function assert;
 use function count;
 use function is_array;
 use function is_int;
+use MacFJA\RediSearch\Exception\UnexpectedServerResponseException;
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamedOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
@@ -32,9 +33,6 @@ use MacFJA\RediSearch\Redis\Response\AggregateResponseItem;
 use MacFJA\RediSearch\Redis\Response\ArrayResponseTrait;
 use MacFJA\RediSearch\Redis\Response\CursorResponse;
 
-/**
- * @method CursorResponse parseResponse(mixed $data)
- */
 class CursorRead extends AbstractCommand
 {
     use ArrayResponseTrait;
@@ -102,18 +100,27 @@ class CursorRead extends AbstractCommand
         return new CursorResponse($cursorId, $totalCount, $items, $size, $index, $rediSearchVersion);
     }
 
-    protected function getRequiredOptions(): array
+    /**
+     * @param array|mixed $data
+     *
+     * @return CursorResponse
+     */
+    public function parseResponse($data)
     {
-        return ['type', 'index', 'cursor'];
-    }
+        if (!is_array($data)) {
+            throw new UnexpectedServerResponseException($data);
+        }
 
-    protected function transformParsedResponse($data)
-    {
         return self::transformResponse(
             $data,
             $this->options['count']->getValue(),
             $this->options['index']->getValue(),
             $this->getRediSearchVersion()
         );
+    }
+
+    protected function getRequiredOptions(): array
+    {
+        return ['type', 'index', 'cursor'];
     }
 }

--- a/src/Redis/Command/CursorRead.php
+++ b/src/Redis/Command/CursorRead.php
@@ -77,7 +77,7 @@ class CursorRead extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.CURSOR';
     }

--- a/src/Redis/Command/DictAdd.php
+++ b/src/Redis/Command/DictAdd.php
@@ -59,7 +59,7 @@ class DictAdd extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.DICTADD';
     }

--- a/src/Redis/Command/DictDel.php
+++ b/src/Redis/Command/DictDel.php
@@ -59,7 +59,7 @@ class DictDel extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.DICTDEL';
     }

--- a/src/Redis/Command/DictDump.php
+++ b/src/Redis/Command/DictDump.php
@@ -42,7 +42,7 @@ class DictDump extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.DICTDUMP';
     }

--- a/src/Redis/Command/DropIndex.php
+++ b/src/Redis/Command/DropIndex.php
@@ -23,11 +23,7 @@ namespace MacFJA\RediSearch\Redis\Command;
 
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
-use Predis\Response\Status;
 
-/**
- * @method Status parseResponse(mixed $data)
- */
 class DropIndex extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -52,7 +48,7 @@ class DropIndex extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.DROPINDEX';
     }

--- a/src/Redis/Command/Explain.php
+++ b/src/Redis/Command/Explain.php
@@ -50,7 +50,7 @@ class Explain extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.EXPLAIN';
     }

--- a/src/Redis/Command/ExplainCli.php
+++ b/src/Redis/Command/ExplainCli.php
@@ -26,7 +26,7 @@ namespace MacFJA\RediSearch\Redis\Command;
  */
 class ExplainCli extends Explain
 {
-    public function getId()
+    public function getId(): string
     {
         return 'FT.EXPLAINCLI';
     }

--- a/src/Redis/Command/Info.php
+++ b/src/Redis/Command/Info.php
@@ -43,7 +43,7 @@ class Info extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.INFO';
     }

--- a/src/Redis/Command/PaginatedCommand.php
+++ b/src/Redis/Command/PaginatedCommand.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 
 namespace MacFJA\RediSearch\Redis\Command;
 
-use Predis\Command\CommandInterface;
+use MacFJA\RediSearch\Redis\Command;
 
-interface PaginatedCommand extends CommandInterface
+interface PaginatedCommand extends Command
 {
     public function getOffset(): ?int;
 

--- a/src/Redis/Command/Search.php
+++ b/src/Redis/Command/Search.php
@@ -23,8 +23,8 @@ namespace MacFJA\RediSearch\Redis\Command;
 
 use function assert;
 use function count;
-use InvalidArgumentException;
 use function is_array;
+use MacFJA\RediSearch\Exception\UnexpectedServerResponseException;
 use MacFJA\RediSearch\Redis\Command\Option\CustomValidatorOption as CV;
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamedOption;
@@ -302,15 +302,15 @@ class Search extends AbstractCommand implements PaginatedCommand
     /**
      * @param mixed $data
      *
-     * @return mixed|PaginatedResponse
+     * @return PaginatedResponse
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function transformParsedResponse($data)
+    public function parseResponse($data)
     {
         if (!is_array($data)) {
-            return $data;
+            throw new UnexpectedServerResponseException($data);
         }
 
         $totalCount = array_shift($data);
@@ -329,7 +329,7 @@ class Search extends AbstractCommand implements PaginatedCommand
 
         $documents = array_chunk($data, $chunkSize);
 
-        $items = array_map(static function ($document) use ($useSortKeys, $usePayloads, $useScores, $noContent) {
+        $items = array_map(static function ($document) use ($data, $useSortKeys, $usePayloads, $useScores, $noContent) {
             $hash = array_shift($document) ?? '';
             $score = true === $useScores ? (float) array_shift($document) : null;
             $payload = true === $usePayloads ? array_shift($document) : null;
@@ -338,7 +338,7 @@ class Search extends AbstractCommand implements PaginatedCommand
             $fields = [];
             if (false === $noContent) {
                 if (!(1 === count($document))) {
-                    throw new InvalidArgumentException();
+                    throw new UnexpectedServerResponseException($data, 'Incomplete response');
                 }
                 $rawData = reset($document);
                 assert(is_array($rawData));

--- a/src/Redis/Command/Search.php
+++ b/src/Redis/Command/Search.php
@@ -25,7 +25,6 @@ use function assert;
 use function count;
 use InvalidArgumentException;
 use function is_array;
-use function is_int;
 use MacFJA\RediSearch\Redis\Command\Option\CustomValidatorOption as CV;
 use MacFJA\RediSearch\Redis\Command\Option\FlagOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamedOption;
@@ -315,7 +314,8 @@ class Search extends AbstractCommand implements PaginatedCommand
         }
 
         $totalCount = array_shift($data);
-        assert(is_int($totalCount));
+        assert(is_numeric($totalCount));
+        $totalCount = (int) $totalCount;
 
         $useScores = $this->options['withscores']->isActive();
         $usePayloads = $this->options['withpayloads']->isActive();

--- a/src/Redis/Command/Search.php
+++ b/src/Redis/Command/Search.php
@@ -279,7 +279,7 @@ class Search extends AbstractCommand implements PaginatedCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SEARCH';
     }

--- a/src/Redis/Command/SpellCheck.php
+++ b/src/Redis/Command/SpellCheck.php
@@ -78,7 +78,7 @@ class SpellCheck extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SPELLCHECK';
     }

--- a/src/Redis/Command/SpellCheck.php
+++ b/src/Redis/Command/SpellCheck.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis\Command;
 
 use function is_array;
+use MacFJA\RediSearch\Exception\UnexpectedServerResponseException;
 use MacFJA\RediSearch\Redis\Command\Option\CustomValidatorOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamedOption;
 use MacFJA\RediSearch\Redis\Command\Option\NamelessOption;
@@ -29,9 +30,6 @@ use MacFJA\RediSearch\Redis\Command\SpellCheckCommand\TermsOption;
 use MacFJA\RediSearch\Redis\Response\SpellCheckResponseItem;
 use Respect\Validation\Validator;
 
-/**
- * @method array<SpellCheckResponseItem> parseResponse(mixed $data)
- */
 class SpellCheck extends AbstractCommand
 {
     public function __construct(string $rediSearchVersion = self::MIN_IMPLEMENTED_VERSION)
@@ -83,20 +81,15 @@ class SpellCheck extends AbstractCommand
         return 'FT.SPELLCHECK';
     }
 
-    protected function getRequiredOptions(): array
-    {
-        return ['index', 'query'];
-    }
-
     /**
      * @param mixed $data
      *
-     * @return mixed|SpellCheckResponseItem[]
+     * @return SpellCheckResponseItem[]
      */
-    protected function transformParsedResponse($data)
+    public function parseResponse($data)
     {
         if (!is_array($data)) {
-            return $data;
+            throw new UnexpectedServerResponseException($data);
         }
 
         $items = array_map(static function (array $group) {
@@ -112,5 +105,10 @@ class SpellCheck extends AbstractCommand
         }, $data);
 
         return array_filter($items);
+    }
+
+    protected function getRequiredOptions(): array
+    {
+        return ['index', 'query'];
     }
 }

--- a/src/Redis/Command/SugAdd.php
+++ b/src/Redis/Command/SugAdd.php
@@ -79,7 +79,7 @@ class SugAdd extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SUGADD';
     }

--- a/src/Redis/Command/SugDel.php
+++ b/src/Redis/Command/SugDel.php
@@ -50,7 +50,7 @@ class SugDel extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SUGDEL';
     }

--- a/src/Redis/Command/SugGet.php
+++ b/src/Redis/Command/SugGet.php
@@ -92,7 +92,7 @@ class SugGet extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SUGGET';
     }

--- a/src/Redis/Command/SugLen.php
+++ b/src/Redis/Command/SugLen.php
@@ -42,7 +42,7 @@ class SugLen extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SUGLEN';
     }

--- a/src/Redis/Command/SynDump.php
+++ b/src/Redis/Command/SynDump.php
@@ -39,7 +39,7 @@ class SynDump extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SYNDUMP';
     }

--- a/src/Redis/Command/SynUpdate.php
+++ b/src/Redis/Command/SynUpdate.php
@@ -66,7 +66,7 @@ class SynUpdate extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.SYNUPDATE';
     }

--- a/src/Redis/Command/TagVals.php
+++ b/src/Redis/Command/TagVals.php
@@ -50,7 +50,7 @@ class TagVals extends AbstractCommand
         return $this;
     }
 
-    public function getId()
+    public function getId(): string
     {
         return 'FT.TAGVALS';
     }

--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace MacFJA\RediSearch\Redis;
 
+use function count;
 use MacFJA\RediSearch\Redis\Command\Aggregate;
 use MacFJA\RediSearch\Redis\Command\AliasAdd;
 use MacFJA\RediSearch\Redis\Command\AliasDel;
@@ -49,6 +50,34 @@ use MacFJA\RediSearch\Redis\Command\SynDump;
 use MacFJA\RediSearch\Redis\Command\SynUpdate;
 use MacFJA\RediSearch\Redis\Command\TagVals;
 use Predis\Profile\RedisProfile;
+use Rediska_Command_Abstract;
+use Rediska_Commands;
+use Rediska_Connection_Exec;
+
+if (class_exists(Rediska_Command_Abstract::class) && class_exists(Rediska_Connection_Exec::class)) {
+    /**
+     * @codeCoverageIgnore
+     */
+    class RediskaRediSearch extends Rediska_Command_Abstract
+    {
+        public function create(): Rediska_Connection_Exec
+        {
+            $connections = $this->_rediska->getConnections();
+
+            if (count($connections) > 1) {
+                trigger_error('Warning, Multiple redis connections exists, only the first connection will be used', E_USER_NOTICE);
+            }
+            $connection = reset($connections);
+
+            $commands = $this->_arguments;
+            if (!('__redisearch' === $this->_name)) {
+                array_unshift($commands, $this->_name);
+            }
+
+            return new Rediska_Connection_Exec($connection, $commands);
+        }
+    }
+}
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -58,7 +87,7 @@ class Initializer
     /**
      * @codeCoverageIgnore
      */
-    public static function registerCommands(RedisProfile $profile): void
+    public static function registerCommandsPredis(RedisProfile $profile): void
     {
         $profile->defineCommand('ftaggregate', Aggregate::class);
         $profile->defineCommand('ftaliasadd', AliasAdd::class);
@@ -89,15 +118,50 @@ class Initializer
         $profile->defineCommand('fttagvals', TagVals::class);
     }
 
+    /**
+     * @codeCoverageIgnore
+     */
+    public static function registerCommandsRediska(): void
+    {
+        Rediska_Commands::add('ftaggregate', RediskaRediSearch::class);
+        Rediska_Commands::add('ftaliasadd', RediskaRediSearch::class);
+        Rediska_Commands::add('ftaliasdel', RediskaRediSearch::class);
+        Rediska_Commands::add('ftaliasupdate', RediskaRediSearch::class);
+        Rediska_Commands::add('ftalter', RediskaRediSearch::class);
+        Rediska_Commands::add('ftconfig', RediskaRediSearch::class);
+        Rediska_Commands::add('ftconfigset', RediskaRediSearch::class);
+        Rediska_Commands::add('ftcreate', RediskaRediSearch::class);
+        Rediska_Commands::add('ftcursordel', RediskaRediSearch::class);
+        Rediska_Commands::add('ftcursorread', RediskaRediSearch::class);
+        Rediska_Commands::add('ftdictadd', RediskaRediSearch::class);
+        Rediska_Commands::add('ftdictdel', RediskaRediSearch::class);
+        Rediska_Commands::add('ftdictdump', RediskaRediSearch::class);
+        Rediska_Commands::add('ftdropindex', RediskaRediSearch::class);
+        Rediska_Commands::add('ftexplain', RediskaRediSearch::class);
+        Rediska_Commands::add('ftexplaincli', RediskaRediSearch::class);
+        Rediska_Commands::add('ftlist', RediskaRediSearch::class);
+        Rediska_Commands::add('ftinfo', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsearch', RediskaRediSearch::class);
+        Rediska_Commands::add('ftspellcheck', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsugadd', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsugdel', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsugget', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsuglen', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsyndump', RediskaRediSearch::class);
+        Rediska_Commands::add('ftsynupdate', RediskaRediSearch::class);
+        Rediska_Commands::add('fttagvals', RediskaRediSearch::class);
+        Rediska_Commands::add('__redisearch', RediskaRediSearch::class);
+    }
+
     public static function getRediSearchVersion(Client $client): ?string
     {
-        $modules = $client->executeRaw('info', 'Modules')['Modules'] ?? [];
+        $modules = $client->executeRaw('module', 'list') ?? [];
 
         foreach ($modules as $module) {
             $data = array_column(
-                array_map(
-                    static function ($line) { return explode('=', $line); },
-                    explode(',', $module)
+                array_chunk(
+                    $module,
+                    2
                 ),
                 1,
                 0

--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -48,7 +48,6 @@ use MacFJA\RediSearch\Redis\Command\SugLen;
 use MacFJA\RediSearch\Redis\Command\SynDump;
 use MacFJA\RediSearch\Redis\Command\SynUpdate;
 use MacFJA\RediSearch\Redis\Command\TagVals;
-use Predis\ClientInterface;
 use Predis\Profile\RedisProfile;
 
 /**
@@ -90,9 +89,9 @@ class Initializer
         $profile->defineCommand('fttagvals', TagVals::class);
     }
 
-    public static function getRediSearchVersion(ClientInterface $client): ?string
+    public static function getRediSearchVersion(Client $client): ?string
     {
-        $modules = $client->info('Modules')['Modules'] ?? [];
+        $modules = $client->executeRaw('info', 'Modules')['Modules'] ?? [];
 
         foreach ($modules as $module) {
             $data = array_column(

--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis;
 
 use function count;
+use MacFJA\RediSearch\Redis\Client\AbstractClient;
 use MacFJA\RediSearch\Redis\Command\Aggregate;
 use MacFJA\RediSearch\Redis\Command\AliasAdd;
 use MacFJA\RediSearch\Redis\Command\AliasDel;
@@ -64,7 +65,7 @@ if (class_exists(Rediska_Command_Abstract::class) && class_exists(Rediska_Connec
         {
             $connections = $this->_rediska->getConnections();
 
-            if (count($connections) > 1) {
+            if (false === AbstractClient::$disableNotice && count($connections) > 1) {
                 trigger_error('Warning, Multiple redis connections exists, only the first connection will be used', E_USER_NOTICE);
             }
             $connection = reset($connections);

--- a/src/Redis/Response.php
+++ b/src/Redis/Response.php
@@ -19,42 +19,8 @@ declare(strict_types=1);
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-namespace MacFJA\RediSearch\Redis\Command;
+namespace MacFJA\RediSearch\Redis;
 
-use MacFJA\RediSearch\Redis\Command;
-
-class IndexList implements Command
+interface Response
 {
-    /** @var string */
-    private $rediSearchVersion = AbstractCommand::MIN_IMPLEMENTED_VERSION;
-
-    public function getId(): string
-    {
-        return 'FT._LIST';
-    }
-
-    public function getRediSearchVersion(): string
-    {
-        return $this->rediSearchVersion;
-    }
-
-    /**
-     * @return IndexList
-     */
-    public function setRediSearchVersion(string $rediSearchVersion): Command
-    {
-        $this->rediSearchVersion = $rediSearchVersion;
-
-        return $this;
-    }
-
-    public function getArguments(): array
-    {
-        return [];
-    }
-
-    public function parseResponse($data)
-    {
-        return $data;
-    }
 }

--- a/src/Redis/Response/CursorResponse.php
+++ b/src/Redis/Response/CursorResponse.php
@@ -73,7 +73,7 @@ class CursorResponse implements Response, Iterator
     }
 
     /**
-     * @return array<AggregateResponseItem>|array<SearchResponseItem>
+     * @return array<AggregateResponseItem>
      */
     public function current()
     {

--- a/src/Redis/Response/CursorResponse.php
+++ b/src/Redis/Response/CursorResponse.php
@@ -23,21 +23,21 @@ namespace MacFJA\RediSearch\Redis\Response;
 
 use function count;
 use Iterator;
+use MacFJA\RediSearch\Redis\Client;
 use MacFJA\RediSearch\Redis\Command\AbstractCommand;
 use MacFJA\RediSearch\Redis\Command\CursorRead;
-use Predis\ClientInterface;
-use Predis\Response\ResponseInterface;
+use MacFJA\RediSearch\Redis\Response;
 
 /**
  * @implements Iterator<int,AggregateResponseItem[]>
  */
-class CursorResponse implements ResponseInterface, Iterator
+class CursorResponse implements Response, Iterator
 {
     /** @var array<AggregateResponseItem> */
     private $items;
     /** @var int */
     private $totalCount;
-    /** @var ClientInterface */
+    /** @var Client */
     private $client;
     /** @var bool */
     private $doNext = false;
@@ -65,7 +65,7 @@ class CursorResponse implements ResponseInterface, Iterator
         $this->cursorId = $cursorId;
     }
 
-    public function setClient(ClientInterface $client): self
+    public function setClient(Client $client): self
     {
         $this->client = $client;
 
@@ -83,7 +83,7 @@ class CursorResponse implements ResponseInterface, Iterator
             $cursorRead->setCursorId($this->cursorId);
             $cursorRead->setCount($this->getPageSize());
             /** @var CursorResponse $next */
-            $next = $this->client->executeCommand($cursorRead);
+            $next = $this->client->execute($cursorRead);
             $this->cursorId = $next->cursorId;
             $this->offset += count($this->items);
             $this->items = $next->items;

--- a/src/Redis/Response/InfoResponse.php
+++ b/src/Redis/Response/InfoResponse.php
@@ -26,6 +26,7 @@ use BadMethodCallException;
 use function in_array;
 use InvalidArgumentException;
 use function is_array;
+use function is_object;
 use function is_string;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\CreateCommandFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\GeoFieldOption;
@@ -33,8 +34,8 @@ use MacFJA\RediSearch\Redis\Command\CreateCommand\NumericFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\TagFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\TextFieldOption;
 use MacFJA\RediSearch\Redis\Command\Option\GroupedOption;
-use Predis\Response\ResponseInterface;
-use Predis\Response\Status;
+use MacFJA\RediSearch\Redis\Response;
+use Stringable;
 
 /**
  * @method string     getIndexName()
@@ -61,7 +62,7 @@ use Predis\Response\Status;
  * @method array      getCursorStats()
  * @method array      getStopwordsList()
  */
-class InfoResponse implements ResponseInterface
+class InfoResponse implements Response
 {
     use ArrayResponseTrait;
 
@@ -71,12 +72,12 @@ class InfoResponse implements ResponseInterface
     private const TO_BOOLEAN = ['indexing'];
 
     /**
-     * @var array<array<mixed>|float|int|Status|string>
+     * @var array<array<mixed>|float|int|string>
      */
     private $rawLines;
 
     /**
-     * @param array<array<mixed>|float|int|Status|string> $rawLines
+     * @param array<array<mixed>|float|int|string> $rawLines
      */
     public function __construct($rawLines)
     {
@@ -122,8 +123,8 @@ class InfoResponse implements ResponseInterface
         return array_map(static function (array $field): CreateCommandFieldOption {
             $fieldName = (string) array_shift($field);
             array_walk($field, static function (&$item) {
-                if ($item instanceof Status) {
-                    $item = $item->getPayload();
+                if (is_object($item) && ($item instanceof Stringable || method_exists($item, '__toString'))) {
+                    $item = (string) $item;
                 }
 
                 return $item;

--- a/src/Redis/Response/InfoResponse.php
+++ b/src/Redis/Response/InfoResponse.php
@@ -79,7 +79,7 @@ class InfoResponse implements Response
     /**
      * @param array<array<mixed>|float|int|string> $rawLines
      */
-    public function __construct($rawLines)
+    public function __construct(array $rawLines)
     {
         $this->rawLines = $rawLines;
     }
@@ -233,7 +233,7 @@ class InfoResponse implements Response
      */
     private static function setOptionFlag(CreateCommandFieldOption $commandOption, array $fields, string $key, string $optionName): CreateCommandFieldOption
     {
-        assert($commandOption instanceof TextFieldOption || $commandOption instanceof TagFieldOption);
+        assert($commandOption instanceof GroupedOption);
         if (in_array($key, $fields, true)) {
             $commandOption->setDataOfOption($optionName, true);
         }

--- a/src/Redis/Response/PaginatedResponse.php
+++ b/src/Redis/Response/PaginatedResponse.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\Redis\Response;
 
 use function count;
+use Countable;
 use function is_int;
 use Iterator;
 use MacFJA\RediSearch\Redis\Client;
@@ -31,7 +32,7 @@ use MacFJA\RediSearch\Redis\Response;
 /**
  * @implements Iterator<int,AggregateResponseItem[]|SearchResponseItem[]>
  */
-class PaginatedResponse implements Response, Iterator
+class PaginatedResponse implements Response, Iterator, Countable
 {
     /** @var array<AggregateResponseItem>|array<SearchResponseItem> */
     private $items;
@@ -121,6 +122,11 @@ class PaginatedResponse implements Response, Iterator
     }
 
     public function getTotalCount(): int
+    {
+        return $this->totalCount;
+    }
+
+    public function count()
     {
         return $this->totalCount;
     }

--- a/src/Redis/Response/PaginatedResponse.php
+++ b/src/Redis/Response/PaginatedResponse.php
@@ -24,14 +24,14 @@ namespace MacFJA\RediSearch\Redis\Response;
 use function count;
 use function is_int;
 use Iterator;
+use MacFJA\RediSearch\Redis\Client;
 use MacFJA\RediSearch\Redis\Command\PaginatedCommand;
-use Predis\ClientInterface;
-use Predis\Response\ResponseInterface;
+use MacFJA\RediSearch\Redis\Response;
 
 /**
  * @implements Iterator<int,AggregateResponseItem[]|SearchResponseItem[]>
  */
-class PaginatedResponse implements ResponseInterface, Iterator
+class PaginatedResponse implements Response, Iterator
 {
     /** @var array<AggregateResponseItem>|array<SearchResponseItem> */
     private $items;
@@ -39,7 +39,7 @@ class PaginatedResponse implements ResponseInterface, Iterator
     private $lastCommand;
     /** @var int */
     private $totalCount;
-    /** @var ClientInterface */
+    /** @var Client */
     private $client;
 
     /** @var null|int */
@@ -57,7 +57,7 @@ class PaginatedResponse implements ResponseInterface, Iterator
         $this->lastCommand = $command;
     }
 
-    public function setClient(ClientInterface $client): PaginatedResponse
+    public function setClient(Client $client): PaginatedResponse
     {
         $this->client = $client;
 
@@ -132,7 +132,7 @@ class PaginatedResponse implements ResponseInterface, Iterator
         $nextCommand->setLimit($offset, $size);
 
         /** @var PaginatedResponse $paginated */
-        $paginated = $this->client->executeCommand($nextCommand);
+        $paginated = $this->client->execute($nextCommand);
         $this->lastCommand = $nextCommand;
         $this->totalCount = $paginated->totalCount;
         $this->items = $paginated->items;

--- a/tests/Redis/Command/InfoTest.php
+++ b/tests/Redis/Command/InfoTest.php
@@ -21,10 +21,13 @@ declare(strict_types=1);
 
 namespace MacFJA\RediSearch\tests\Redis\Command;
 
+use MacFJA\RediSearch\Exception\UnexpectedServerResponseException;
 use MacFJA\RediSearch\Redis\Command\Info;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @covers \MacFJA\RediSearch\Exception\UnexpectedServerResponseException
+ *
  * @covers  \MacFJA\RediSearch\Redis\Command\AbstractCommand
  *
  * @covers \MacFJA\RediSearch\Redis\Command\Info
@@ -52,5 +55,12 @@ class InfoTest extends TestCase
         static::assertSame([
             'idx',
         ], $command->getArguments());
+    }
+
+    public function testParseResponseInvalid(): void
+    {
+        $this->expectException(UnexpectedServerResponseException::class);
+        $command = new Info();
+        $command->parseResponse('foo');
     }
 }

--- a/tests/Redis/InitializerTest.php
+++ b/tests/Redis/InitializerTest.php
@@ -39,7 +39,7 @@ class InitializerTest extends \PHPUnit\Framework\TestCase
     public function testRediSearchVersion(array $input, ?string $expected): void
     {
         $client = $this->createMock(Client::class);
-        $client->method('executeRaw')->with('info', 'Modules')->willReturn(['Modules' => $input]);
+        $client->method('executeRaw')->with('module', 'list')->willReturn($input);
 
         static::assertSame($expected, Initializer::getRediSearchVersion($client));
     }
@@ -50,13 +50,13 @@ class InitializerTest extends \PHPUnit\Framework\TestCase
     public function dataProvider(string $testName): Generator
     {
         if ('testRediSearchVersion' === $testName) {
-            yield [['name=search,ver=20005,api=1,filters=0,usedby=[],using=[],options=[]'], '2.0.5'];
-            yield [['name=search,ver=20000,api=1,filters=0,usedby=[],using=[],options=[]'], '2.0.0'];
-            yield [['name=search,ver=26512,api=1,filters=0,usedby=[],using=[],options=[]'], '2.65.12'];
-            yield [['name=search,ver=120569,api=1,filters=0,usedby=[],using=[],options=[]'], '12.5.69'];
-            yield [['name=search,ver=99999,api=1,filters=0,usedby=[],using=[],options=[]'], '9.99.99'];
-            yield [['name=json,ver=99999,api=1,filters=0,usedby=[],using=[],options=[]'], null];
-            yield [['name=json,ver=99999,api=1,filters=0,usedby=[],using=[],options=[]', 'name=search,ver=20005,api=1,filters=0,usedby=[],using=[],options=[]'], '2.0.5'];
+            yield [[['name', 'search', 'ver', '20005']], '2.0.5'];
+            yield [[['name', 'search', 'ver', '20000']], '2.0.0'];
+            yield [[['name', 'search', 'ver', '26512']], '2.65.12'];
+            yield [[['name', 'search', 'ver', '120569']], '12.5.69'];
+            yield [[['name', 'search', 'ver', '99999']], '9.99.99'];
+            yield [[['name', 'json', 'ver', '99999']], null];
+            yield [[['name', 'json', 'ver', '99999'], ['name', 'search', 'ver', '20005']], '2.0.5'];
         }
     }
 }

--- a/tests/Redis/InitializerTest.php
+++ b/tests/Redis/InitializerTest.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 namespace MacFJA\RediSearch\tests\Redis;
 
 use Generator;
+use MacFJA\RediSearch\Redis\Client;
 use MacFJA\RediSearch\Redis\Initializer;
-use Predis\Client;
 
 /**
  * @covers \MacFJA\RediSearch\Redis\Initializer
@@ -38,11 +38,8 @@ class InitializerTest extends \PHPUnit\Framework\TestCase
      */
     public function testRediSearchVersion(array $input, ?string $expected): void
     {
-        $client = $this->getMockBuilder(Client::class)
-            ->addMethods(['info'])
-            ->getMock()
-        ;
-        $client->method('info')->with('Modules')->willReturn(['Modules' => $input]);
+        $client = $this->createMock(Client::class);
+        $client->method('executeRaw')->with('info', 'Modules')->willReturn(['Modules' => $input]);
 
         static::assertSame($expected, Initializer::getRediSearchVersion($client));
     }

--- a/tests/Redis/Response/InfoResponseTest.php
+++ b/tests/Redis/Response/InfoResponseTest.php
@@ -30,7 +30,6 @@ use Predis\Response\Status;
 
 /**
  * @covers \MacFJA\RediSearch\Redis\Command\AbstractCommand::parseResponse
- * @covers \MacFJA\RediSearch\Redis\Command\AbstractCommand::transformParsedResponse
  * @covers \MacFJA\RediSearch\Redis\Command\Info
  * @covers \MacFJA\RediSearch\Redis\Response\InfoResponse
  *

--- a/tests/fixtures/Redis/Command/FakeAbstractCommand.php
+++ b/tests/fixtures/Redis/Command/FakeAbstractCommand.php
@@ -29,7 +29,7 @@ class FakeAbstractCommand extends \MacFJA\RediSearch\Redis\Command\AbstractComma
     /** @var array<string> */
     private $requiredOptions;
 
-    public function getId()
+    public function getId(): string
     {
         return '';
     }

--- a/tests/integration/DockerTest.php
+++ b/tests/integration/DockerTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\tests\integration;
+
+use Amp\Redis\Config;
+use Amp\Redis\RemoteExecutor;
+use Closure;
+use MacFJA\RediSearch\Index;
+use MacFJA\RediSearch\IndexBuilder;
+use MacFJA\RediSearch\Query\Builder;
+use MacFJA\RediSearch\Query\Builder\Fuzzy;
+use MacFJA\RediSearch\Redis\Client;
+use MacFJA\RediSearch\Redis\Command\Aggregate;
+use MacFJA\RediSearch\Redis\Command\AggregateCommand\GroupByOption;
+use MacFJA\RediSearch\Redis\Command\AggregateCommand\ReduceOption;
+use MacFJA\RediSearch\Redis\Command\DropIndex;
+use MacFJA\RediSearch\Redis\Command\IndexList;
+use MacFJA\RediSearch\Redis\Command\Search;
+use MacFJA\RediSearch\Redis\Command\SynDump;
+use MacFJA\RediSearch\Redis\Command\SynUpdate;
+use MacFJA\RediSearch\Redis\Response\PaginatedResponse;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestResult;
+use Rediska;
+
+/**
+ * @covers \MacFJA\RediSearch\Index
+ * @covers \MacFJA\RediSearch\IndexBuilder
+ * @covers \MacFJA\RediSearch\Query\Builder
+ * @covers \MacFJA\RediSearch\Redis\Client\AbstractClient
+ * @covers \MacFJA\RediSearch\Redis\Client\AmpRedisClient
+ * @covers \MacFJA\RediSearch\Redis\Client\CheprasovRedisClient
+ * @covers \MacFJA\RediSearch\Redis\Client\PredisClient
+ * @covers \MacFJA\RediSearch\Redis\Client\RedisentClient
+ * @covers \MacFJA\RediSearch\Redis\Client\RediskaClient
+ * @covers \MacFJA\RediSearch\Redis\Command\Aggregate
+ * @covers \MacFJA\RediSearch\Redis\Command\DropIndex
+ * @covers \MacFJA\RediSearch\Redis\Command\IndexList
+ * @covers \MacFJA\RediSearch\Redis\Command\Info
+ * @covers \MacFJA\RediSearch\Redis\Command\Search
+ * @covers \MacFJA\RediSearch\Redis\Command\SynDump
+ * @covers \MacFJA\RediSearch\Redis\Command\SynUpdate
+ * @covers \MacFJA\RediSearch\Redis\Initializer
+ * @covers \MacFJA\RediSearch\Redis\RediskaRediSearch
+ * @covers \MacFJA\RediSearch\Redis\Response\InfoResponse
+ * @covers \MacFJA\RediSearch\Redis\Response\PaginatedResponse
+ *
+ * @uses \MacFJA\RediSearch\Query\Builder\AbstractGroup
+ * @uses \MacFJA\RediSearch\Query\Builder\AndGroup
+ * @uses \MacFJA\RediSearch\Redis\Command\AbstractCommand
+ * @uses \MacFJA\RediSearch\Redis\Command\AddFieldOptionTrait
+ * @uses \MacFJA\RediSearch\Redis\Command\AggregateCommand\GroupByOption
+ * @uses \MacFJA\RediSearch\Redis\Command\AggregateCommand\ReduceOption
+ * @uses \MacFJA\RediSearch\Redis\Command\AggregateCommand\WithCursor
+ * @uses \MacFJA\RediSearch\Redis\Command\Create
+ * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\BaseCreateFieldOptionTrait
+ * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\NumericFieldOption
+ * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\TextFieldOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\AbstractCommandOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\CustomValidatorOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\DecoratedOptionTrait
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\FlagOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\GroupedOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\NamedOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\NamelessOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\NotEmptyOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\NumberedOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\WithPublicGroupedSetterTrait
+ * @uses \MacFJA\RediSearch\Redis\Command\PrefixFieldName
+ * @uses \MacFJA\RediSearch\Redis\Command\SearchCommand\GeoFilterOption
+ * @uses \MacFJA\RediSearch\Redis\Command\SearchCommand\HighlightOption
+ * @uses \MacFJA\RediSearch\Redis\Command\SearchCommand\LimitOption
+ * @uses \MacFJA\RediSearch\Redis\Command\SearchCommand\SortByOption
+ * @uses \MacFJA\RediSearch\Redis\Command\SearchCommand\SummarizeOption
+ * @uses \MacFJA\RediSearch\Redis\Command\AggregateCommand\SortByOption
+ * @uses \MacFJA\RediSearch\Query\Builder\Fuzzy
+ * @uses \MacFJA\RediSearch\Query\Escaper
+ *
+ * @group integration
+ *
+ * @internal
+ */
+class DockerTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        exec('which docker', $output, $code);
+        if ($code > 0) {
+            static::markTestSkipped('Docker is missing');
+        }
+        exec('docker run --rm -p 16379:6379 -d redislabs/redisearch:latest');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        exec('docker ps --filter publish=16379 -q', $output);
+        foreach ($output as $container) {
+            exec('docker stop '.escapeshellarg($container), $output);
+        }
+    }
+
+    /**
+     * @dataProvider dataProvider
+     * @large
+     *
+     * @param mixed $clientBuilder
+     */
+    public function testIntegration($clientBuilder): void
+    {
+        $client = $clientBuilder();
+        $resultObject = $this->getTestResultObject();
+        if ($resultObject instanceof TestResult) {
+            $resultObject->beStrictAboutOutputDuringTests(false);
+            $resultObject->convertNoticesToExceptions(false);
+        }
+
+        $list = $client->execute(new IndexList());
+        static::assertEmpty($list);
+        $builder = new IndexBuilder();
+        $builder
+            ->withIndex('testDoc')
+            ->addTextField('lastname', false, null, null, true)
+            ->addTextField('firstname')
+            ->addNumericField('age')
+            ->create($client)
+        ;
+        static::assertEquals(['testDoc'], $client->execute(new IndexList()));
+
+        $index = new Index('testDoc', $client);
+        $docToRemove = [];
+        $docToRemove[] = $index->addDocumentFromArray(['firstname' => 'Joe', 'lastname' => 'Doe', 'age' => 30]);
+        $docToRemove[] = $index->addDocumentFromArray(['firstname' => 'Joe', 'age' => 30]);
+        $docToRemove[] = $index->addDocumentFromArray(['firstname' => 'Joe', 'age' => 30, 'fullname' => 'eeeee']);
+
+        $search = new Search();
+
+        $query = (new Builder())
+            ->addElement(new Fuzzy('Joo'))
+        ;
+
+        $search
+            ->setIndex('testDoc')
+            ->setQuery($query->render())
+            ->setWithPayloads()
+            ->setHighlight(['lastname'], '<b>', '</b>')
+            ->setWithScores()
+        ;
+
+        /** @var PaginatedResponse $result */
+        $result = $client->execute($search);
+        static::assertCount(3, $result);
+        $client->execute((new SynUpdate())->setIndex('testDoc')->setGroupId('Joe')->setTerms('John'));
+        $syns = $client->execute((new SynDump())->setIndex('testDoc'));
+        static::assertEquals([
+            'john', ['Joe'],
+        ], $syns);
+
+        $result = $client->pipeline(
+            (new Search())
+                ->setIndex('testDoc')
+                ->setQuery('%%Joe%%')
+                ->setWithPayloads()
+                ->setWithScores()
+                ->setHighlight(['lastname'], '<b>', '</b>'),
+            (new Aggregate())
+                ->setIndex('testDoc')
+                ->setQuery('*')
+                ->addGroupBy(new GroupByOption(['lastname'], [ReduceOption::count('count')])),
+            (new Aggregate())
+                ->setIndex('testDoc')
+                ->setQuery('*')
+                ->addGroupBy(new GroupByOption(['firstname'], [ReduceOption::count('count')])),
+            (new Aggregate())
+                ->setIndex('testDoc')
+                ->setQuery('*')
+                ->addGroupBy(new GroupByOption(['age'], [ReduceOption::count('count')])),
+            (new Aggregate())
+                ->setIndex('testDoc')
+                ->setQuery('*')
+                ->addGroupBy(new GroupByOption([], [ReduceOption::toList('age', 'list')]))
+        );
+
+        static::assertCount(3, $result[0]);
+        static::assertEquals('1', current($result[1])[0]->getValue('count'));
+        static::assertEquals('2', current($result[1])[1]->getValue('count'));
+        static::assertEquals('3', current($result[2])[0]->getValue('count'));
+        static::assertEquals('3', current($result[3])[0]->getValue('count'));
+        static::assertEquals(['30'], current($result[4])[0]->getValue('list'));
+
+        $client->execute((new DropIndex())->setIndex('testDoc')->setDeleteDocument());
+        $client->executeRaw('del', ...$docToRemove);
+    }
+
+    /**
+     * @return Closure[][]
+     */
+    public function dataProvider(): array
+    {
+        return [
+            [static function () { return Client\PredisClient::make(new \Predis\Client(['scheme' => 'tcp', 'host' => 'localhost', 'port' => '16379', 'db' => 0])); }],
+            [static function () { return Client\RediskaClient::make(new Rediska(['servers' => [['host' => 'localhost', 'port' => '16379', 'db' => 0]]])); }],
+            [static function () { return Client\RedisentClient::make(new \redisent\Redis('redis://localhost:16379')); }],
+            [static function () { return Client\CheprasovRedisClient::make(new \RedisClient\Client\Version\RedisClient6x0(['server' => 'localhost:16379', 'database' => 0])); }],
+            [static function () { return Client\AmpRedisClient::make(new \Amp\Redis\Redis(new RemoteExecutor(Config::fromUri('redis://localhost:16379')))); }],
+        ];
+    }
+}

--- a/tests/psalm/stubs/phpiredis.php
+++ b/tests/psalm/stubs/phpiredis.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+const PHPIREDIS_READER_STATE_COMPLETE = 1;
+const PHPIREDIS_READER_STATE_INCOMPLETE = 2;
+const PHPIREDIS_READER_STATE_ERROR = 3;
+
+const PHPIREDIS_REPLY_STRING = 1;
+const PHPIREDIS_REPLY_ARRAY = 2;
+const PHPIREDIS_REPLY_INTEGER = 3;
+const PHPIREDIS_REPLY_NIL = 4;
+const PHPIREDIS_REPLY_STATUS = 5;
+const PHPIREDIS_REPLY_ERROR = 6;
+
+function phpiredis_connect($host, $port = 6379): void
+{
+}
+function phpiredis_pconnect($host, $port = 6379): void
+{
+}
+function phpiredis_disconnect(): void
+{
+}
+/**
+ * @param resource $redis
+ * @param string[] $command
+ *
+ * @return bool|string
+ */
+function phpiredis_command_bs($redis, array $command)
+{
+}
+
+/**
+ * @param resource $redis
+ *
+ * @return bool|string
+ */
+function phpiredis_command($redis, string $command)
+{
+}
+/**
+ * @param resource      $redis
+ * @param array<string> $commands
+ *
+ * @return array<bool|string>
+ */
+function phpiredis_multi_command($redis, array $commands)
+{
+}
+
+/**
+ * @param resource             $redis
+ * @param array<array<string>> $commands
+ *
+ * @return array<bool|string>
+ */
+function phpiredis_multi_command_bs($redis, array $commands)
+{
+}
+
+/**
+ * @param array<float|int|string> $args
+ */
+function phpiredis_format_command(array $args): string
+{
+}
+
+/**
+ * @return resource
+ */
+function phpiredis_reader_create()
+{
+}
+
+/**
+ * @param resource $reader
+ */
+function phpiredis_reader_reset($reader): void
+{
+}
+
+/**
+ * @param resource $reader
+ */
+function phpiredis_reader_feed($reader, string $response): void
+{
+}
+
+/**
+ * @param resource $reader
+ *
+ * @return bool|int
+ */
+function phpiredis_reader_get_state($reader)
+{
+}
+/**
+ * @param resource $reader
+ *
+ * @return bool|string
+ */
+function phpiredis_reader_get_error($reader)
+{
+}
+
+/**
+ * @param resource $reader
+ *
+ * @return array<array|bool|int|string>|bool|int|string
+ */
+function phpiredis_reader_get_reply($reader, int &$type)
+{
+}
+
+/**
+ * @param resource $redis
+ */
+function phpiredis_reader_destroy($redis): void
+{
+}
+
+/**
+ * @param resource $reader
+ */
+function phpiredis_reader_set_error_handler($reader, ?callable $handler): void
+{
+}
+/**
+ * @param resource $reader
+ */
+function phpiredis_reader_set_status_handler($reader, ?callable $handler): void
+{
+}
+function phpiredis_utils_crc16(string $data): int
+{
+}


### PR DESCRIPTION
Changes to allow more Redis Lib (pure PHP, or extension).

List of currently handled connector:
 - [`ext-phpiredis`](https://github.com/nrk/phpiredis)
 - [`ext-phpredis`](https://github.com/phpredis/phpredis)
 - [`amphp/redis`](https://github.com/amphp/redis) [Integration test]
 - [`cheprasov/php-redis-client`](https://github.com/cheprasov/php-redis-client) [Integration test]
 - [`colinmollenhour/credis`](https://github.com/colinmollenhour/credis) [Integration test]
 - [`geometria-lab/rediska`](https://github.com/Shumkov/Rediska) [Integration test] [Abandoned?]
 - [`predis/predis`](https://github.com/nrk/predis) [Integration test]
 - [`redisent/redisent`](https://github.com/jdp/redisent) [Integration test] [Abandoned?]
 - [`ptrofimov/tinyredisclient`](https://github.com/ptrofimov/tinyredisclient) [Integration test]

Close #16 