### PR TITLE
Add support for JSON document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased v2.x]
 
+### Added
+
+- Support from JSON document (require RediSearch 2.2)
+
+### Fixed
+
+- (dev) Code coverage with XDebug 3
+
 ## [2.0.2]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,18 @@ test-with-integration: | vendor
 
 coverage: | vendor
 	@if [ -z "`php -v | grep -i 'xdebug'`" ]; then echo "You need to install Xdebug in order to do this action"; exit 1; fi
-	$(COMPOSER) exec -v phpunit -- --coverage-text --color
+	XDEBUG_MODE=coverage $(COMPOSER) exec -v phpunit -- --coverage-text --color
 
 coverage-with-integration: | vendor
 	@if [ -z "`php -v | grep -i 'xdebug'`" ]; then echo "You need to install Xdebug in order to do this action"; exit 1; fi
-	$(COMPOSER) exec -v phpunit -- --group default,integration --coverage-text --color
+	XDEBUG_MODE=coverage $(COMPOSER) exec -v phpunit -- --group default,integration --coverage-text --color
 
 integration-test: | vendor
 	$(COMPOSER) exec -v phpunit -- --group integration
 
 integration-coverage: | vendor
 	@if [ -z "`php -v | grep -i 'xdebug'`" ]; then echo "You need to install Xdebug in order to do this action"; exit 1; fi
-	$(COMPOSER) exec -v phpunit -- --group integration --coverage-text --color
+	XDEBUG_MODE=coverage $(COMPOSER) exec -v phpunit -- --group integration --coverage-text --color
 
 validation: fix-code analyze test-with-integration coverage-with-integration
 

--- a/src/IndexBuilder.php
+++ b/src/IndexBuilder.php
@@ -34,6 +34,7 @@ use MacFJA\RediSearch\Redis\Command\AbstractCommand;
 use MacFJA\RediSearch\Redis\Command\AddFieldOptionTrait;
 use MacFJA\RediSearch\Redis\Command\Create;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\CreateCommandFieldOption;
+use MacFJA\RediSearch\Redis\Command\CreateCommand\JSONFieldOption;
 use RuntimeException;
 use function strlen;
 
@@ -84,6 +85,10 @@ use function strlen;
  * @method IndexBuilder withAddedNumericField(string $name, bool $sortable = false, bool $noIndex = false)
  * @method IndexBuilder withAddedGeoField(string $name, bool $noIndex = false)
  * @method IndexBuilder withAddedTagField(string $name, ?string $separator = null, bool $sortable = false, bool $noIndex = false)
+ * @method IndexBuilder withAddedJSONTextField(string $path, string $attribute, bool $noStem = false, ?float $weight = null, ?string $phonetic = null, bool $sortable = false, bool $noIndex = false)
+ * @method IndexBuilder withAddedJSONNumericField(string $path, string $attribute, bool $sortable = false, bool $noIndex = false)
+ * @method IndexBuilder withAddedJSONGeoField(string $path, string $attribute, bool $noIndex = false)
+ * @method IndexBuilder withAddedJSONTagField(string $path, string $attribute, ?string $separator = null, bool $sortable = false, bool $noIndex = false)
  *
  * @SuppressWarnings(PHPMD.TooManyFields)
  */
@@ -181,6 +186,13 @@ class IndexBuilder
     public function addField(CreateCommandFieldOption $option): self
     {
         $this->fields[] = $option;
+
+        return $this;
+    }
+
+    public function addJSONField(string $path, CreateCommandFieldOption $option): self
+    {
+        $this->fields[$option->getFieldName()] = new JSONFieldOption($path, $option);
 
         return $this;
     }

--- a/src/Redis/Command/AddFieldOptionTrait.php
+++ b/src/Redis/Command/AddFieldOptionTrait.php
@@ -25,6 +25,7 @@ use BadMethodCallException;
 use function get_class;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\CreateCommandFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\GeoFieldOption;
+use MacFJA\RediSearch\Redis\Command\CreateCommand\JSONFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\NumericFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\TagFieldOption;
 use MacFJA\RediSearch\Redis\Command\CreateCommand\TextFieldOption;
@@ -75,6 +76,54 @@ trait AddFieldOptionTrait
         );
     }
 
+    public function addJSONTextField(string $path, string $attribute, bool $noStem = false, ?float $weight = null, ?string $phonetic = null, bool $sortable = false, bool $noIndex = false): self
+    {
+        return $this->addJSONField(
+            $path,
+            (new TextFieldOption())
+                ->setField($attribute)
+                ->setNoStem($noStem)
+                ->setWeight($weight)
+                ->setPhonetic($phonetic)
+                ->setSortable($sortable)
+                ->setNoIndex($noIndex)
+        );
+    }
+
+    public function addJSONNumericField(string $path, string $attribute, bool $sortable = false, bool $noIndex = false): self
+    {
+        return $this->addJSONField(
+            $path,
+            (new NumericFieldOption())
+                ->setField($attribute)
+                ->setSortable($sortable)
+                ->setNoIndex($noIndex)
+        );
+    }
+
+    public function addJSONGeoField(string $path, string $attribute, bool $noIndex = false): self
+    {
+        return $this->addJSONField(
+            $path,
+            (new GeoFieldOption())
+                ->setField($attribute)
+                ->setNoIndex($noIndex)
+        );
+    }
+
+    public function addJSONTagField(string $path, string $attribute, ?string $separator = null, bool $sortable = false, bool $noIndex = false, bool $caseSensitive = false): self
+    {
+        return $this->addJSONField(
+            $path,
+            (new TagFieldOption())
+                ->setField($attribute)
+                ->setSeparator($separator)
+                ->setCaseSensitive($caseSensitive)
+                ->setSortable($sortable)
+                ->setNoIndex($noIndex)
+        );
+    }
+
     public function addField(CreateCommandFieldOption $option): self
     {
         if (!($this instanceof AbstractCommand)) {
@@ -82,6 +131,17 @@ trait AddFieldOptionTrait
         }
 
         $this->options['fields'][$option->getFieldName()] = $option;
+
+        return $this;
+    }
+
+    public function addJSONField(string $path, CreateCommandFieldOption $option): self
+    {
+        if (!($this instanceof AbstractCommand)) {
+            throw new BadMethodCallException('This method is not callable in '.get_class($this));
+        }
+
+        $this->options['fields'][$option->getFieldName()] = new JSONFieldOption($path, $option);
 
         return $this;
     }

--- a/src/Redis/Command/Create.php
+++ b/src/Redis/Command/Create.php
@@ -37,7 +37,10 @@ class Create extends AbstractCommand
     {
         parent::__construct([
             'index' => new NamelessOption(null, '>=2.0.0'),
-            'structure' => CV::allowedValues(new NamedOption('ON', null, '>=2.0.0'), ['HASH']),
+            'structure' => [
+                CV::allowedValues(new NamedOption('ON', null, '>=2.0.0 <2.2.0'), ['HASH']),
+                CV::allowedValues(new NamedOption('ON', null, '>=2.2.0'), ['HASH', 'JSON']),
+            ],
             'prefixes' => new NotEmptyOption(new NumberedOption('PREFIX', null, '>=2.0.0')),
             'filter' => new NamedOption('FILTER', null, '>=2.0.0'),
             'default_lang' => $this->getLanguageOptions(),
@@ -67,7 +70,9 @@ class Create extends AbstractCommand
 
     public function setStructure(string $structureType = 'HASH'): self
     {
-        $this->options['structure']->setValue($structureType);
+        array_walk($this->options['structure'], static function (CV $option) use ($structureType): void {
+            $option->setValue($structureType);
+        });
 
         return $this;
     }

--- a/src/Redis/Command/CreateCommand/CreateCommandJSONFieldOption.php
+++ b/src/Redis/Command/CreateCommand/CreateCommandJSONFieldOption.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Command\CreateCommand;
+
+interface CreateCommandJSONFieldOption extends CreateCommandFieldOption
+{
+    public function getJSONPath(): string;
+}

--- a/src/Redis/Command/CreateCommand/JSONFieldOption.php
+++ b/src/Redis/Command/CreateCommand/JSONFieldOption.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\Redis\Command\CreateCommand;
+
+use MacFJA\RediSearch\Redis\Command\Option\AbstractCommandOption;
+
+class JSONFieldOption extends AbstractCommandOption implements CreateCommandJSONFieldOption
+{
+    /** @var CreateCommandFieldOption */
+    private $decorated;
+    /** @var string */
+    private $path;
+
+    public function __construct(string $path, CreateCommandFieldOption $decorated)
+    {
+        parent::__construct('>=2.2.0');
+        $this->path = $path;
+        $this->decorated = $decorated;
+    }
+
+    public function isValid(): bool
+    {
+        return !empty($this->path) && $this->decorated->isValid();
+    }
+
+    public function getOptionData()
+    {
+        return array_merge(['path' => $this->path], $this->decorated->getOptionData());
+    }
+
+    public function getVersionConstraint(): string
+    {
+        return '>=2.2.0';
+    }
+
+    public function getFieldName(): string
+    {
+        return $this->decorated->getFieldName();
+    }
+
+    public function getJSONPath(): string
+    {
+        return $this->path;
+    }
+
+    protected function doRender(?string $version): array
+    {
+        return array_merge([$this->path, 'AS'], $this->decorated->render($version));
+    }
+}

--- a/tests/IndexBuilderTest.php
+++ b/tests/IndexBuilderTest.php
@@ -48,6 +48,7 @@ use RuntimeException;
  * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\GeoFieldOption
  * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\NumericFieldOption
  * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\TagFieldOption
+ * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\JSONFieldOption
  * @uses \MacFJA\RediSearch\Redis\Command\Option\DecoratedOptionAwareTrait
  * @uses \MacFJA\RediSearch\Redis\Command\Option\GroupedOption
  * @uses \MacFJA\RediSearch\Redis\Command\Option\WithPublicGroupedSetterTrait
@@ -249,6 +250,45 @@ class IndexBuilderTest extends TestCase
 
         $builder->addTagField('languages');
         $createCommand->addTagField('languages');
+        static::assertEquals($createCommand, $builder->getCommand());
+    }
+
+    public function testAllJsonAdd(): void
+    {
+        $createCommand = new Create();
+
+        $builder = new IndexBuilder();
+
+        $builder->setIndex('city');
+        $createCommand->setIndex('city');
+
+        $oldBuilder = $builder;
+        $builder = $builder->addPrefixes('city-', 'c-');
+        static::assertNotEquals($createCommand, $builder->getCommand());
+        $createCommand->setPrefixes('city-', 'c-');
+        static::assertEquals($createCommand, $builder->getCommand());
+        static::assertSame($oldBuilder, $builder);
+
+        $builder->addStopWords('hello', 'world');
+        $createCommand->setStopWords('hello', 'world');
+
+        $builder->addJSONField('$.city.name', (new TextFieldOption())->setField('name'));
+        $createCommand->addJSONTextField('$.city.name', 'name');
+
+        $builder->addJSONField('$.city.country', (new TextFieldOption())->setField('country'));
+        $createCommand->addJSONTextField('$.city.country', 'country');
+
+        $builder->addJSONTextField('$.city.continent', 'continent');
+        $createCommand->addJSONTextField('$.city.continent', 'continent');
+
+        $builder->addJSONNumericField('$.city.population', 'population');
+        $createCommand->addJSONNumericField('$.city.population', 'population');
+
+        $builder->addJSONGeoField('$.city.gps', 'gps');
+        $createCommand->addJSONGeoField('$.city.gps', 'gps');
+
+        $builder->addJSONTagField('$.city.languages', 'languages');
+        $createCommand->addJSONTagField('$.city.languages', 'languages');
         static::assertEquals($createCommand, $builder->getCommand());
     }
 

--- a/tests/Redis/Command/AddFieldOptionTraitTest.php
+++ b/tests/Redis/Command/AddFieldOptionTraitTest.php
@@ -51,6 +51,16 @@ class AddFieldOptionTraitTest extends \PHPUnit\Framework\TestCase
         $command->addNumericField('foo');
     }
 
+    public function testWrongParent2(): void
+    {
+        $command = new FakeAddFieldOptionTraitClass1();
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('This method is not callable in '.FakeAddFieldOptionTraitClass1::class);
+
+        $command->addJSONNumericField('$.foo', 'foo');
+    }
+
     public function testValidParent(): void
     {
         $command = new FakeAddFieldOptionTraitClass2([]);

--- a/tests/Redis/Command/AggregateTest.php
+++ b/tests/Redis/Command/AggregateTest.php
@@ -60,6 +60,13 @@ class AggregateTest extends TestCase
         static::assertSame('FT.AGGREGATE', $command->getId());
     }
 
+    public function testGetIndex(): void
+    {
+        $command = new Aggregate();
+        $command->setIndex('idx');
+        static::assertSame('idx', $command->getIndex());
+    }
+
     public function testMultiReduce(): void
     {
         $group = new GroupByOption(['@text1']);

--- a/tests/Redis/Command/Option/JSONFieldOptionTest.php
+++ b/tests/Redis/Command/Option/JSONFieldOptionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright MacFJA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace MacFJA\RediSearch\tests\Redis\Command\Option;
+
+use MacFJA\RediSearch\Redis\Command\CreateCommand\JSONFieldOption;
+use MacFJA\RediSearch\Redis\Command\CreateCommand\TextFieldOption;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MacFJA\RediSearch\Redis\Command\CreateCommand\JSONFieldOption
+ *
+ * @uses \MacFJA\RediSearch\Redis\Command\CreateCommand\TextFieldOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\AbstractCommandOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\CustomValidatorOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\DecoratedCommandOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\FlagOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\GroupedOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\NamedOption
+ * @uses \MacFJA\RediSearch\Redis\Command\Option\NamelessOption
+ *
+ * @internal
+ */
+class JSONFieldOptionTest extends TestCase
+{
+    public function testIsValid(): void
+    {
+        $option = new TextFieldOption();
+        $json = new JSONFieldOption('$.data', $option);
+
+        static::assertFalse($option->isValid());
+        static::assertFalse($json->isValid());
+
+        $option->setField('data');
+        $json = new JSONFieldOption('', $option);
+        static::assertTrue($option->isValid());
+        static::assertFalse($json->isValid());
+
+        $json = new JSONFieldOption('$.data', $option);
+        static::assertTrue($option->isValid());
+        static::assertTrue($json->isValid());
+    }
+
+    public function testGetOptionData(): void
+    {
+        $option = new TextFieldOption();
+        $option->setField('data');
+        $json = new JSONFieldOption('$.data', $option);
+
+        $expected = [
+            'path' => '$.data',
+        ] + $option->getOptionData();
+
+        static::assertSame($expected, $json->getOptionData());
+    }
+
+    public function testGetVersionConstraint(): void
+    {
+        $option = new TextFieldOption();
+        $json = new JSONFieldOption('$.data', $option);
+
+        static::assertSame('>=2.2.0', $json->getVersionConstraint());
+    }
+
+    public function testGetFieldName(): void
+    {
+        $option = new TextFieldOption();
+        $option->setField('data');
+        $json = new JSONFieldOption('$.data', $option);
+
+        static::assertSame('data', $json->getFieldName());
+    }
+
+    public function testGetJSONPath(): void
+    {
+        $option = new TextFieldOption();
+        $json = new JSONFieldOption('$.data', $option);
+
+        static::assertSame('$.data', $json->getJSONPath());
+    }
+
+    public function testDoRender(): void
+    {
+        $option = new TextFieldOption();
+        $option->setField('data');
+        $json = new JSONFieldOption('$.data', $option);
+
+        static::assertSame(['$.data', 'AS', 'data', 'TEXT'], $json->render());
+    }
+}


### PR DESCRIPTION
Close #22 

- Add support for JSON document.
- Add methods in the Create command, Alter command and IndexBuilder for quick adding JSON field