### PR TITLE
Return empty modules array when module command is not available

### DIFF
--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -128,7 +128,14 @@ class Initializer
 
     public static function getRediSearchVersion(Client $client): ?string
     {
-        $modules = $client->executeRaw('module', 'list') ?? [];
+        try {
+            $modules = $client->executeRaw('module', 'list') ?? [];
+        } catch (\Throwable $exception) {
+            if (strpos($exception->getMessage(), 'unknown command') === false) {
+                throw $exception;
+            }
+            $modules = [];
+        }
 
         foreach ($modules as $module) {
             $data = array_column(

--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -131,7 +131,7 @@ class Initializer
         try {
             $modules = $client->executeRaw('module', 'list') ?? [];
         } catch (\Throwable $exception) {
-            if (strpos($exception->getMessage(), 'unknown command') === false) {
+            if (strpos($exception->getMessage(), 'unknown command') !== false) {
                 throw $exception;
             }
             $modules = [];

--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -131,7 +131,7 @@ class Initializer
         try {
             $modules = $client->executeRaw('module', 'list') ?? [];
         } catch (\Throwable $exception) {
-            if (strpos($exception->getMessage(), 'unknown command') !== false) {
+            if (strpos($exception->getMessage(), 'unknown command') === false) {
                 throw $exception;
             }
             $modules = [];


### PR DESCRIPTION
When connecting to a Redis server with limited rights the module command may not be available. Predis throws an exception and executing commands is not possible. This happend with Redis Enterprise Cloud server where Redisearch is available but the module command not. 