### PR TITLE
Add Predis v2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documentation on paginated responses
 - Throw custom exception is client is missing
+- Add compatibility for Predis version 2.x
+- (dev) Add `make clean` to remove all generated files
 
 ### Fixed
 
@@ -18,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rework paginated responses
+- Add warning for Predis commands initialization
+- (dev) Remove deprecated `--no-suggest` option of Composer in the `Makefile`
 
 ### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: analyze fix-code test test-with-integration coverage coverage-with-integration validation integration-test integration-coverage
+.PHONY: analyze fix-code clean test test-with-integration coverage coverage-with-integration validation integration-test integration-coverage
 
 analyze: | vendor
 	$(COMPOSER) exec -v parallel-lint -- src
@@ -10,6 +10,13 @@ analyze: | vendor
 	$(COMPOSER) exec -v phpa -- src
 	$(COMPOSER) exec -v phpstan -- analyse
 	$(COMPOSER) exec -v psalm -- src
+
+clean:
+	rm -rf composer.phar
+	rm -rf vendor/
+	rm -rf composer.lock
+	rm -rf .php-cs-fixer.cache
+	rm -rf .phpunit.result.cache
 
 fix-code: | vendor
 	$(COMPOSER) normalize
@@ -39,7 +46,7 @@ integration-coverage: | vendor
 validation: fix-code analyze test-with-integration coverage-with-integration
 
 vendor: composer.json
-	$(COMPOSER) install --optimize-autoloader --no-suggest --prefer-dist
+	$(COMPOSER) install --optimize-autoloader --prefer-dist
 	touch vendor
 
 composer.phar:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ $result = $client->pipeline($search, $stats, $aggregate, $suggestion);
 // $result[3] is the suggestion result
 ```
 
-### Use Predis shorthand syntax
+### Use Predis (v1.x) shorthand syntax
 
 ```php
 $client = new \Predis\Client(/* ... */);

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "phpmd/phpmd": "^2.10",
         "phpstan/phpstan": "^1.2.0",
         "phpunit/phpunit": "^8.5 || ^9.3",
-        "predis/predis": "^1.1",
+        "predis/predis": "^1.1 || ^2.0",
         "ptrofimov/tinyredisclient": "^1.1",
         "redisent/redisent": "dev-master",
         "roave/security-advisories": "dev-latest",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,3 +14,4 @@ parameters:
         -
             message: '#Call to an undefined method MacFJA\\RediSearch\\Redis\\Command\\Option\\CommandOption::set\w+\(\).#'
             path: src/Redis/Command/Option/GroupedOption.php
+        - '#Predis\\Profile\\RedisProfile#'

--- a/src/Redis/Initializer.php
+++ b/src/Redis/Initializer.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace MacFJA\RediSearch\Redis;
 
+use MacFJA\RediSearch\Redis\Client\AbstractClient;
 use MacFJA\RediSearch\Redis\Client\Rediska\RediskaRediSearchCommand;
 use MacFJA\RediSearch\Redis\Command\Aggregate;
 use MacFJA\RediSearch\Redis\Command\AliasAdd;
@@ -59,9 +60,19 @@ class Initializer
 {
     /**
      * @codeCoverageIgnore
+     * @psalm-suppress UndefinedDocblockClass
+     * @psalm-suppress UndefinedClass
+     *
+     * @param RedisProfile $profile
      */
-    public static function registerCommandsPredis(RedisProfile $profile): void
+    public static function registerCommandsPredis($profile): void
     {
+        if (!$profile instanceof RedisProfile) {
+            false === AbstractClient::$disableNotice
+            && trigger_error(sprintf('The parameter $profile must be an instance of %s, which is only available in Predis 1.x.', RedisProfile::class), E_USER_WARNING);
+
+            return;
+        }
         $profile->defineCommand('ftaggregate', Aggregate::class);
         $profile->defineCommand('ftaliasadd', AliasAdd::class);
         $profile->defineCommand('ftaliasdel', AliasDel::class);


### PR DESCRIPTION
### Added

- Add compatibility for Predis version 2.x
- (dev) Add `make clean` to remove all generated files

### Changed

- Add warning for Predis commands initialization
- (dev) Remove deprecated `--no-suggest` option of Composer in the `Makefile`
